### PR TITLE
feat(learning-paths): implement hierarchical learning structure inspi…

### DIFF
--- a/prisma/migrations/20251108000001_add_learning_paths_structure/migration.sql
+++ b/prisma/migrations/20251108000001_add_learning_paths_structure/migration.sql
@@ -1,0 +1,108 @@
+-- CreateEnum
+CREATE TYPE "LessonType" AS ENUM ('THEORY', 'PRACTICE', 'QUIZ', 'PROJECT', 'CHALLENGE');
+
+-- CreateTable: LearningPath
+CREATE TABLE "LearningPath" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "icon" TEXT,
+    "color" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "isPublished" BOOLEAN NOT NULL DEFAULT false,
+    "category" "Category" NOT NULL,
+    "targetRole" "UserRole",
+    "estimatedHours" INTEGER NOT NULL DEFAULT 0,
+    "totalXp" INTEGER NOT NULL DEFAULT 0,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LearningPath_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: LearningUnit
+CREATE TABLE "LearningUnit" (
+    "id" TEXT NOT NULL,
+    "learningPathId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "icon" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "isPublished" BOOLEAN NOT NULL DEFAULT false,
+    "estimatedHours" INTEGER NOT NULL DEFAULT 0,
+    "totalXp" INTEGER NOT NULL DEFAULT 0,
+    "prerequisites" TEXT[],
+    "learningGoals" TEXT[],
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LearningUnit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: Lesson
+CREATE TABLE "Lesson" (
+    "id" TEXT NOT NULL,
+    "learningUnitId" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "icon" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "isPublished" BOOLEAN NOT NULL DEFAULT false,
+    "lessonType" "LessonType" NOT NULL DEFAULT 'PRACTICE',
+    "estimatedMinutes" INTEGER NOT NULL DEFAULT 15,
+    "xpReward" INTEGER NOT NULL DEFAULT 50,
+    "content" JSONB,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Lesson_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: LessonChallenge (junction table)
+CREATE TABLE "LessonChallenge" (
+    "lessonId" TEXT NOT NULL,
+    "challengeId" TEXT NOT NULL,
+    "orderInLesson" INTEGER NOT NULL,
+    "required" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LessonChallenge_pkey" PRIMARY KEY ("lessonId","challengeId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LearningPath_slug_key" ON "LearningPath"("slug");
+CREATE INDEX "LearningPath_slug_idx" ON "LearningPath"("slug");
+CREATE INDEX "LearningPath_category_idx" ON "LearningPath"("category");
+CREATE INDEX "LearningPath_isPublished_idx" ON "LearningPath"("isPublished");
+CREATE INDEX "LearningPath_order_idx" ON "LearningPath"("order");
+
+CREATE UNIQUE INDEX "LearningUnit_slug_key" ON "LearningUnit"("slug");
+CREATE INDEX "LearningUnit_learningPathId_idx" ON "LearningUnit"("learningPathId");
+CREATE INDEX "LearningUnit_slug_idx" ON "LearningUnit"("slug");
+CREATE INDEX "LearningUnit_isPublished_idx" ON "LearningUnit"("isPublished");
+CREATE INDEX "LearningUnit_order_idx" ON "LearningUnit"("order");
+
+CREATE UNIQUE INDEX "Lesson_slug_key" ON "Lesson"("slug");
+CREATE INDEX "Lesson_learningUnitId_idx" ON "Lesson"("learningUnitId");
+CREATE INDEX "Lesson_slug_idx" ON "Lesson"("slug");
+CREATE INDEX "Lesson_lessonType_idx" ON "Lesson"("lessonType");
+CREATE INDEX "Lesson_isPublished_idx" ON "Lesson"("isPublished");
+CREATE INDEX "Lesson_order_idx" ON "Lesson"("order");
+
+CREATE INDEX "LessonChallenge_lessonId_idx" ON "LessonChallenge"("lessonId");
+CREATE INDEX "LessonChallenge_challengeId_idx" ON "LessonChallenge"("challengeId");
+
+-- AddForeignKey
+ALTER TABLE "LearningUnit" ADD CONSTRAINT "LearningUnit_learningPathId_fkey" FOREIGN KEY ("learningPathId") REFERENCES "LearningPath"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Lesson" ADD CONSTRAINT "Lesson_learningUnitId_fkey" FOREIGN KEY ("learningUnitId") REFERENCES "LearningUnit"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "LessonChallenge" ADD CONSTRAINT "LessonChallenge_lessonId_fkey" FOREIGN KEY ("lessonId") REFERENCES "Lesson"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "LessonChallenge" ADD CONSTRAINT "LessonChallenge_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "Challenge"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,132 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Module {
+  id                 String   @id @default(cuid())
+  slug               String   @unique
+  title              String
+  description        String
+  orderIndex         Int      @unique
+
+  iconImage          String
+  theme              Json
+
+  requiredXp         Int      @default(0)
+  requiredLevel      Int      @default(1)
+
+  previousModuleId   String?
+  previousModule     Module?  @relation("ModuleSequence", fields: [previousModuleId], references: [id])
+  nextModules        Module[] @relation("ModuleSequence")
+
+  isLocked           Boolean  @default(true)
+  isNew              Boolean  @default(false)
+
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  challenges         Challenge[]
+  userProgress       UserModuleProgress[]
+  units              Unit[]
+
+  @@index([slug])
+  @@index([orderIndex])
+}
+
+model Unit {
+  id                 String   @id @default(cuid())
+  slug               String   @unique
+  title              String
+  description        String
+
+  moduleId           String
+  module             Module   @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+  orderInModule      Int
+
+  iconImage          String
+  theme              Json     @default("{}")
+
+  learningObjectives String[]
+  estimatedMinutes   Int
+  theoryContent      String   @db.Text
+  resources          Json     @default("{}")
+
+  requiredScore      Float    @default(60)
+
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  levels             Level[]
+  userProgress       UserUnitProgress[]
+
+  @@unique([moduleId, orderInModule])
+  @@index([moduleId])
+  @@index([slug])
+}
+
+model UserModuleProgress {
+  id                    String   @id @default(cuid())
+
+  userId                String
+  user                  User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  moduleId              String
+  module                Module   @relation(fields: [moduleId], references: [id], onDelete: Cascade)
+
+  status                ModuleStatus @default(LOCKED)
+
+  challengesCompleted   Int      @default(0)
+  totalChallenges       Int      @default(0)
+  completionPercentage  Float    @default(0)
+
+  startedAt             DateTime?
+  completedAt           DateTime?
+  lastAccessedAt        DateTime?
+
+  totalXpEarned         Int      @default(0)
+  averageScore          Float    @default(0)
+
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  @@unique([userId, moduleId])
+  @@index([userId])
+  @@index([moduleId])
+  @@index([status])
+}
+
+model UserUnitProgress {
+  id                    String   @id @default(cuid())
+
+  userId                String
+  user                  User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  unitId                String
+  unit                  Unit     @relation(fields: [unitId], references: [id], onDelete: Cascade)
+
+  status                UnitStatus @default(LOCKED)
+
+  levelsCompleted       Int      @default(0)
+  totalLevels           Int      @default(0)
+  completionPercentage  Float    @default(0)
+
+  currentLevelId        String?
+  highestScore          Float    @default(0)
+  attemptsCount         Int      @default(0)
+
+  startedAt             DateTime?
+  completedAt           DateTime?
+  lastAccessedAt        DateTime?
+
+  totalXpEarned         Int      @default(0)
+
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  @@unique([userId, unitId])
+  @@index([userId])
+  @@index([unitId])
+  @@index([status])
+}
 
 model User {
   id                String    @id @default(cuid())
@@ -47,7 +173,10 @@ model User {
   codeEvents       CodeEvent[]
   notifications    Notification[]
   validationLogs   ValidationLog[]
-  
+  moduleProgress   UserModuleProgress[]
+  unitProgress     UserUnitProgress[]
+  levelProgress    UserLevelProgress[]
+
   @@index([email])
   @@index([companyId])
 }
@@ -78,36 +207,240 @@ model Challenge {
   slug              String   @unique
   title             String
   description       String
-  
+
+  moduleId          String?
+  module            Module?   @relation(fields: [moduleId], references: [id])
+  orderInModule     Int?
+
   difficulty        Difficulty
   category          Category
   estimatedMinutes  Int
   languages         String[]
-  
-  instructions      String  
+
+  instructions      String
   starterCode       String?
   solution          String
-  
-  testCases         Json     
-  hints             Json    
-  traps             Json    
-  
+
+  testCases         Json
+  hints             Json
+  traps             Json
+
   baseXp           Int      @default(100)
   bonusXp          Int      @default(50)
-  
-  targetMetrics    Json     
-  
+
+  targetMetrics    Json
+
+  planetImage      String?
+  visualTheme      Json?
+  requiredScore    Float?
+  previousChallengeId String?
+
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
-  
+
   attempts         ChallengeAttempt[]
   validationLogs       ValidationLog[]
   validationRules      ValidationRule[]
   governanceMetrics    GovernanceMetrics[]
-  
+  levelChallenges      LevelChallenge[]
+  lessonChallenges     LessonChallenge[]
+
+  @@unique([moduleId, orderInModule])
   @@index([slug])
   @@index([difficulty])
   @@index([category])
+  @@index([moduleId])
+}
+
+model Level {
+  id                String   @id @default(cuid())
+
+  unitId            String
+  unit              Unit     @relation(fields: [unitId], references: [id], onDelete: Cascade)
+
+  orderInUnit       Int
+  type              LevelType
+
+  icon              String
+  title             String?
+  description       String?
+
+  config            Json     @default("{}")
+
+  adaptive          Boolean  @default(false)
+  blocking          Boolean  @default(true)
+  optional          Boolean  @default(false)
+
+  timeLimit         Int?
+  bonusXp           Int      @default(0)
+
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  challenges        LevelChallenge[]
+  userProgress      UserLevelProgress[]
+
+  @@unique([unitId, orderInUnit])
+  @@index([unitId])
+  @@index([type])
+}
+
+model LevelChallenge {
+  levelId      String
+  level        Level     @relation(fields: [levelId], references: [id], onDelete: Cascade)
+
+  challengeId  String
+  challenge    Challenge @relation(fields: [challengeId], references: [id], onDelete: Cascade)
+
+  orderInLevel Int
+  required     Boolean   @default(true)
+
+  createdAt    DateTime  @default(now())
+
+  @@id([levelId, challengeId])
+  @@index([levelId])
+  @@index([challengeId])
+}
+
+model LearningPath {
+  id          String   @id @default(cuid())
+  slug        String   @unique
+  title       String
+  description String
+  icon        String?
+  color       String?
+
+  order       Int      @default(0)
+  isPublished Boolean  @default(false)
+
+  category    Category
+  targetRole  UserRole?
+
+  estimatedHours Int   @default(0)
+  totalXp        Int   @default(0)
+
+  metadata    Json     @default("{}")
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  learningUnits LearningUnit[]
+
+  @@index([slug])
+  @@index([category])
+  @@index([isPublished])
+  @@index([order])
+}
+
+model LearningUnit {
+  id          String   @id @default(cuid())
+  learningPathId String
+  learningPath   LearningPath @relation(fields: [learningPathId], references: [id], onDelete: Cascade)
+
+  slug        String   @unique
+  title       String
+  description String
+  icon        String?
+
+  order       Int      @default(0)
+  isPublished Boolean  @default(false)
+
+  estimatedHours Int   @default(0)
+  totalXp        Int   @default(0)
+
+  prerequisites String[]
+  learningGoals String[]
+
+  metadata    Json     @default("{}")
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  lessons     Lesson[]
+
+  @@index([learningPathId])
+  @@index([slug])
+  @@index([isPublished])
+  @@index([order])
+}
+
+model Lesson {
+  id          String   @id @default(cuid())
+  learningUnitId String
+  learningUnit   LearningUnit @relation(fields: [learningUnitId], references: [id], onDelete: Cascade)
+
+  slug        String   @unique
+  title       String
+  description String
+  icon        String?
+
+  order       Int      @default(0)
+  isPublished Boolean  @default(false)
+
+  lessonType  LessonType @default(PRACTICE)
+
+  estimatedMinutes Int @default(15)
+  xpReward         Int @default(50)
+
+  content     Json?
+
+  metadata    Json     @default("{}")
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  challenges  LessonChallenge[]
+
+  @@index([learningUnitId])
+  @@index([slug])
+  @@index([lessonType])
+  @@index([isPublished])
+  @@index([order])
+}
+
+model LessonChallenge {
+  lessonId     String
+  lesson       Lesson    @relation(fields: [lessonId], references: [id], onDelete: Cascade)
+
+  challengeId  String
+  challenge    Challenge @relation(fields: [challengeId], references: [id], onDelete: Cascade)
+
+  orderInLesson Int
+  required     Boolean   @default(true)
+
+  createdAt    DateTime  @default(now())
+
+  @@id([lessonId, challengeId])
+  @@index([lessonId])
+  @@index([challengeId])
+}
+
+model UserLevelProgress {
+  id              String   @id @default(cuid())
+
+  userId          String
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  levelId         String
+  level           Level    @relation(fields: [levelId], references: [id], onDelete: Cascade)
+
+  status          LevelStatus @default(LOCKED)
+
+  attemptsCount   Int      @default(0)
+  bestScore       Float    @default(0)
+
+  startedAt       DateTime?
+  completedAt     DateTime?
+
+  xpEarned        Int      @default(0)
+
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@unique([userId, levelId])
+  @@index([userId])
+  @@index([levelId])
+  @@index([status])
 }
 
 model ChallengeAttempt {
@@ -582,4 +915,44 @@ enum NotificationPriority {
   low
   medium
   high
+}
+
+enum ModuleStatus {
+  LOCKED
+  AVAILABLE
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum LevelType {
+  LESSON
+  PRACTICE
+  STORY
+  UNIT_REVIEW
+  MATCH_MADNESS
+  RAPID_REVIEW
+  XP_RAMP_UP
+}
+
+enum UnitStatus {
+  LOCKED
+  AVAILABLE
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum LevelStatus {
+  LOCKED
+  AVAILABLE
+  IN_PROGRESS
+  COMPLETED
+  PERFECT
+}
+
+enum LessonType {
+  THEORY
+  PRACTICE
+  QUIZ
+  PROJECT
+  CHALLENGE
 }

--- a/src/modules/learning-paths/README.md
+++ b/src/modules/learning-paths/README.md
@@ -1,0 +1,68 @@
+# Learning Paths Module
+
+## Overview
+This module implements a hierarchical learning structure inspired by Duolingo, parallel to the existing Module/Unit/Level structure.
+
+## Hierarchy
+
+```
+LearningPath (e.g., "Backend Developer Path")
+  └── LearningUnit (e.g., "RESTful APIs")
+      └── Lesson (e.g., "HTTP Methods")
+          └── Challenge (via LessonChallenge junction table)
+```
+
+## Models
+
+### LearningPath
+- Represents a complete learning journey (e.g., "Backend Developer", "Frontend Mastery")
+- Contains multiple LearningUnits
+- Has category, targetRole, estimatedHours, totalXp
+- Can be published/unpublished
+
+### LearningUnit
+- A thematic unit within a LearningPath
+- Contains multiple Lessons
+- Supports prerequisites (other units that must be completed first)
+- Has learningGoals and metadata
+
+### Lesson
+- Individual learning content unit
+- Types: THEORY, PRACTICE, QUIZ, PROJECT, CHALLENGE
+- Can contain multiple Challenges via LessonChallenge junction table
+- Has estimatedMinutes and xpReward
+
+### LessonChallenge
+- Junction table linking Lessons to existing Challenges
+- Allows ordering challenges within a lesson
+- Supports required vs optional challenges
+
+## Coexistence with Existing Structure
+
+This structure coexists with the existing Module/Unit/Level hierarchy:
+
+**Existing**: Module → Unit → Level → Challenge (via LevelChallenge)
+**New**: LearningPath → LearningUnit → Lesson → Challenge (via LessonChallenge)
+
+Both can reference the same Challenge, allowing flexible content organization.
+
+## Implementation Status
+
+### ✅ Completed
+- Database schema (Prisma models)
+- Migration SQL
+
+### 🚧 TODO
+- Domain entities (LearningPathEntity, LearningUnitEntity, LessonEntity)
+- Repository interfaces and implementations
+- Use cases (CRUD operations)
+- Controllers and routes
+- Fastify plugin registration
+- Progress tracking (UserLearningPathProgress, etc.)
+
+## Notes
+
+- Names were chosen to avoid conflicts with existing `Unit` model
+- All tables support soft delete via `isPublished` flag
+- Metadata JSON fields allow for future extensibility
+- Cascade deletes maintain referential integrity

--- a/src/modules/learning-paths/application/use-cases/create-lesson.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/create-lesson.use-case.ts
@@ -1,0 +1,76 @@
+import { Lesson } from '@prisma/client';
+import { ILessonRepository } from '../../domain/repositories/lesson.repository.interface';
+import { IUnitRepository } from '../../domain/repositories/unit.repository.interface';
+import { CreateLessonDTO } from '../../domain/schemas/learning-path.schema';
+import { LessonSlugExistsError, UnitNotFoundError } from '../../domain/errors';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class CreateLessonUseCase {
+  constructor(
+    private readonly lessonRepository: ILessonRepository,
+    private readonly unitRepository: IUnitRepository
+  ) {}
+
+  async execute(data: CreateLessonDTO): Promise<Lesson> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        useCase: 'CreateLesson',
+        slug: data.slug,
+        title: data.title,
+        unitId: data.unitId,
+        lessonType: data.lessonType,
+      },
+      'Executing CreateLesson use case'
+    );
+
+    try {
+      // Check if unit exists
+      const unitExists = await this.unitRepository.findById(data.unitId);
+      if (!unitExists) {
+        throw new UnitNotFoundError(data.unitId);
+      }
+
+      // Check if slug already exists
+      const slugExists = await this.lessonRepository.existsBySlug(data.slug);
+      if (slugExists) {
+        throw new LessonSlugExistsError(data.slug);
+      }
+
+      const lesson = await this.lessonRepository.create(data);
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          useCase: 'CreateLesson',
+          lessonId: lesson.id,
+          slug: lesson.slug,
+          title: lesson.title,
+          unitId: lesson.unitId,
+          lessonType: lesson.lessonType,
+          processingTime,
+        },
+        'Lesson created successfully'
+      );
+
+      return lesson;
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          useCase: 'CreateLesson',
+          slug: data.slug,
+          unitId: data.unitId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to create lesson'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/create-path.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/create-path.use-case.ts
@@ -1,0 +1,62 @@
+import { Path } from '@prisma/client';
+import { IPathRepository } from '../../domain/repositories/path.repository.interface';
+import { CreatePathDTO } from '../../domain/schemas/learning-path.schema';
+import { PathSlugExistsError } from '../../domain/errors';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class CreatePathUseCase {
+  constructor(private readonly pathRepository: IPathRepository) {}
+
+  async execute(data: CreatePathDTO): Promise<Path> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        useCase: 'CreatePath',
+        slug: data.slug,
+        title: data.title,
+        category: data.category,
+      },
+      'Executing CreatePath use case'
+    );
+
+    try {
+      // Check if slug already exists
+      const slugExists = await this.pathRepository.existsBySlug(data.slug);
+      if (slugExists) {
+        throw new PathSlugExistsError(data.slug);
+      }
+
+      const path = await this.pathRepository.create(data);
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          useCase: 'CreatePath',
+          pathId: path.id,
+          slug: path.slug,
+          title: path.title,
+          processingTime,
+        },
+        'Path created successfully'
+      );
+
+      return path;
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          useCase: 'CreatePath',
+          slug: data.slug,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to create path'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/create-unit.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/create-unit.use-case.ts
@@ -1,0 +1,74 @@
+import { Unit } from '@prisma/client';
+import { IUnitRepository } from '../../domain/repositories/unit.repository.interface';
+import { IPathRepository } from '../../domain/repositories/path.repository.interface';
+import { CreateUnitDTO } from '../../domain/schemas/learning-path.schema';
+import { UnitSlugExistsError, PathNotFoundError } from '../../domain/errors';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class CreateUnitUseCase {
+  constructor(
+    private readonly unitRepository: IUnitRepository,
+    private readonly pathRepository: IPathRepository
+  ) {}
+
+  async execute(data: CreateUnitDTO): Promise<Unit> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        useCase: 'CreateUnit',
+        slug: data.slug,
+        title: data.title,
+        pathId: data.pathId,
+      },
+      'Executing CreateUnit use case'
+    );
+
+    try {
+      // Check if path exists
+      const pathExists = await this.pathRepository.findById(data.pathId);
+      if (!pathExists) {
+        throw new PathNotFoundError(data.pathId);
+      }
+
+      // Check if slug already exists
+      const slugExists = await this.unitRepository.existsBySlug(data.slug);
+      if (slugExists) {
+        throw new UnitSlugExistsError(data.slug);
+      }
+
+      const unit = await this.unitRepository.create(data);
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          useCase: 'CreateUnit',
+          unitId: unit.id,
+          slug: unit.slug,
+          title: unit.title,
+          pathId: unit.pathId,
+          processingTime,
+        },
+        'Unit created successfully'
+      );
+
+      return unit;
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          useCase: 'CreateUnit',
+          slug: data.slug,
+          pathId: data.pathId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to create unit'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/get-lesson.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/get-lesson.use-case.ts
@@ -1,0 +1,56 @@
+import { ILessonRepository } from '../../domain/repositories/lesson.repository.interface';
+import { LessonWithRelations } from '../../domain/types/learning-path.types';
+import { LessonNotFoundError } from '../../domain/errors';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class GetLessonUseCase {
+  constructor(private readonly lessonRepository: ILessonRepository) {}
+
+  async execute(identifier: string, includeChallenges = false): Promise<LessonWithRelations> {
+    logger.info(
+      {
+        useCase: 'GetLesson',
+        identifier,
+        includeChallenges,
+      },
+      'Executing GetLesson use case'
+    );
+
+    try {
+      // Try to find by ID first, then by slug
+      let lesson = await this.lessonRepository.findById(identifier, includeChallenges);
+
+      if (!lesson) {
+        lesson = await this.lessonRepository.findBySlug(identifier, includeChallenges);
+      }
+
+      if (!lesson) {
+        throw new LessonNotFoundError(identifier);
+      }
+
+      logger.info(
+        {
+          useCase: 'GetLesson',
+          lessonId: lesson.id,
+          slug: lesson.slug,
+          lessonType: lesson.lessonType,
+          challengesCount: lesson._count?.challenges || 0,
+        },
+        'Lesson retrieved successfully'
+      );
+
+      return lesson;
+    } catch (error) {
+      logger.error(
+        {
+          useCase: 'GetLesson',
+          identifier,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to get lesson'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/get-path.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/get-path.use-case.ts
@@ -1,0 +1,55 @@
+import { IPathRepository } from '../../domain/repositories/path.repository.interface';
+import { PathWithRelations } from '../../domain/types/learning-path.types';
+import { PathNotFoundError } from '../../domain/errors';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class GetPathUseCase {
+  constructor(private readonly pathRepository: IPathRepository) {}
+
+  async execute(identifier: string, includeUnits = false): Promise<PathWithRelations> {
+    logger.info(
+      {
+        useCase: 'GetPath',
+        identifier,
+        includeUnits,
+      },
+      'Executing GetPath use case'
+    );
+
+    try {
+      // Try to find by ID first, then by slug
+      let path = await this.pathRepository.findById(identifier, includeUnits);
+
+      if (!path) {
+        path = await this.pathRepository.findBySlug(identifier, includeUnits);
+      }
+
+      if (!path) {
+        throw new PathNotFoundError(identifier);
+      }
+
+      logger.info(
+        {
+          useCase: 'GetPath',
+          pathId: path.id,
+          slug: path.slug,
+          unitsCount: path._count?.units || 0,
+        },
+        'Path retrieved successfully'
+      );
+
+      return path;
+    } catch (error) {
+      logger.error(
+        {
+          useCase: 'GetPath',
+          identifier,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to get path'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/get-unit.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/get-unit.use-case.ts
@@ -1,0 +1,55 @@
+import { IUnitRepository } from '../../domain/repositories/unit.repository.interface';
+import { UnitWithRelations } from '../../domain/types/learning-path.types';
+import { UnitNotFoundError } from '../../domain/errors';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class GetUnitUseCase {
+  constructor(private readonly unitRepository: IUnitRepository) {}
+
+  async execute(identifier: string, includeLessons = false): Promise<UnitWithRelations> {
+    logger.info(
+      {
+        useCase: 'GetUnit',
+        identifier,
+        includeLessons,
+      },
+      'Executing GetUnit use case'
+    );
+
+    try {
+      // Try to find by ID first, then by slug
+      let unit = await this.unitRepository.findById(identifier, includeLessons);
+
+      if (!unit) {
+        unit = await this.unitRepository.findBySlug(identifier, includeLessons);
+      }
+
+      if (!unit) {
+        throw new UnitNotFoundError(identifier);
+      }
+
+      logger.info(
+        {
+          useCase: 'GetUnit',
+          unitId: unit.id,
+          slug: unit.slug,
+          lessonsCount: unit._count?.lessons || 0,
+        },
+        'Unit retrieved successfully'
+      );
+
+      return unit;
+    } catch (error) {
+      logger.error(
+        {
+          useCase: 'GetUnit',
+          identifier,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to get unit'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/index.ts
+++ b/src/modules/learning-paths/application/use-cases/index.ts
@@ -1,0 +1,14 @@
+// Path use cases
+export * from './create-path.use-case';
+export * from './get-path.use-case';
+export * from './list-paths.use-case';
+
+// Unit use cases
+export * from './create-unit.use-case';
+export * from './get-unit.use-case';
+export * from './list-units.use-case';
+
+// Lesson use cases
+export * from './create-lesson.use-case';
+export * from './get-lesson.use-case';
+export * from './list-lessons.use-case';

--- a/src/modules/learning-paths/application/use-cases/list-lessons.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/list-lessons.use-case.ts
@@ -1,0 +1,73 @@
+import { ILessonRepository } from '../../domain/repositories/lesson.repository.interface';
+import { LessonQueryDTO } from '../../domain/schemas/learning-path.schema';
+import { LessonWithRelations } from '../../domain/types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export interface ListLessonsResult {
+  lessons: LessonWithRelations[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export class ListLessonsUseCase {
+  constructor(private readonly lessonRepository: ILessonRepository) {}
+
+  async execute(filters?: LessonQueryDTO): Promise<ListLessonsResult> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        useCase: 'ListLessons',
+        filters,
+      },
+      'Executing ListLessons use case'
+    );
+
+    try {
+      const lessons = await this.lessonRepository.findAll(filters);
+      const total = await this.lessonRepository.count(filters);
+
+      const page = filters?.page || 1;
+      const limit = filters?.limit || 20;
+      const totalPages = Math.ceil(total / limit);
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          useCase: 'ListLessons',
+          count: lessons.length,
+          total,
+          page,
+          totalPages,
+          processingTime,
+        },
+        'Lessons listed successfully'
+      );
+
+      return {
+        lessons,
+        total,
+        page,
+        limit,
+        totalPages,
+      };
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          useCase: 'ListLessons',
+          filters,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to list lessons'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/list-paths.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/list-paths.use-case.ts
@@ -1,0 +1,73 @@
+import { IPathRepository } from '../../domain/repositories/path.repository.interface';
+import { PathQueryDTO } from '../../domain/schemas/learning-path.schema';
+import { PathWithRelations } from '../../domain/types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export interface ListPathsResult {
+  paths: PathWithRelations[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export class ListPathsUseCase {
+  constructor(private readonly pathRepository: IPathRepository) {}
+
+  async execute(filters?: PathQueryDTO): Promise<ListPathsResult> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        useCase: 'ListPaths',
+        filters,
+      },
+      'Executing ListPaths use case'
+    );
+
+    try {
+      const paths = await this.pathRepository.findAll(filters);
+      const total = await this.pathRepository.count(filters);
+
+      const page = filters?.page || 1;
+      const limit = filters?.limit || 20;
+      const totalPages = Math.ceil(total / limit);
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          useCase: 'ListPaths',
+          count: paths.length,
+          total,
+          page,
+          totalPages,
+          processingTime,
+        },
+        'Paths listed successfully'
+      );
+
+      return {
+        paths,
+        total,
+        page,
+        limit,
+        totalPages,
+      };
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          useCase: 'ListPaths',
+          filters,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to list paths'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/application/use-cases/list-units.use-case.ts
+++ b/src/modules/learning-paths/application/use-cases/list-units.use-case.ts
@@ -1,0 +1,73 @@
+import { IUnitRepository } from '../../domain/repositories/unit.repository.interface';
+import { UnitQueryDTO } from '../../domain/schemas/learning-path.schema';
+import { UnitWithRelations } from '../../domain/types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export interface ListUnitsResult {
+  units: UnitWithRelations[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export class ListUnitsUseCase {
+  constructor(private readonly unitRepository: IUnitRepository) {}
+
+  async execute(filters?: UnitQueryDTO): Promise<ListUnitsResult> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        useCase: 'ListUnits',
+        filters,
+      },
+      'Executing ListUnits use case'
+    );
+
+    try {
+      const units = await this.unitRepository.findAll(filters);
+      const total = await this.unitRepository.count(filters);
+
+      const page = filters?.page || 1;
+      const limit = filters?.limit || 20;
+      const totalPages = Math.ceil(total / limit);
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          useCase: 'ListUnits',
+          count: units.length,
+          total,
+          page,
+          totalPages,
+          processingTime,
+        },
+        'Units listed successfully'
+      );
+
+      return {
+        units,
+        total,
+        page,
+        limit,
+        totalPages,
+      };
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          useCase: 'ListUnits',
+          filters,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to list units'
+      );
+
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/domain/entities/index.ts
+++ b/src/modules/learning-paths/domain/entities/index.ts
@@ -1,0 +1,3 @@
+export * from './path.entity';
+export * from './unit.entity';
+export * from './lesson.entity';

--- a/src/modules/learning-paths/domain/entities/lesson.entity.ts
+++ b/src/modules/learning-paths/domain/entities/lesson.entity.ts
@@ -1,0 +1,263 @@
+import { Lesson as PrismaLesson } from '@prisma/client';
+import { CreateLessonDTO } from '../schemas/learning-path.schema';
+import { LessonContent, LessonMetadata, LessonType } from '../types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class LessonEntity {
+  private constructor(private readonly props: PrismaLesson) {}
+
+  static create(data: CreateLessonDTO): LessonEntity {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        operation: 'lesson_entity_creation',
+        slug: data.slug,
+        title: data.title,
+        unitId: data.unitId,
+        lessonType: data.lessonType,
+        estimatedMinutes: data.estimatedMinutes,
+        xpReward: data.xpReward,
+        isPublished: data.isPublished,
+        order: data.order,
+      },
+      'Creating lesson entity'
+    );
+
+    try {
+      const metadata = typeof data.metadata === 'string'
+        ? data.metadata
+        : JSON.stringify(data.metadata || {});
+
+      const content = data.content
+        ? typeof data.content === 'string'
+          ? data.content
+          : JSON.stringify(data.content)
+        : null;
+
+      const props = {
+        id: '', // Will be set by Prisma
+        unitId: data.unitId,
+        slug: data.slug,
+        title: data.title,
+        description: data.description,
+        icon: data.icon || null,
+        order: data.order ?? 0,
+        isPublished: data.isPublished ?? false,
+        lessonType: (data.lessonType || 'PRACTICE') as any,
+        estimatedMinutes: data.estimatedMinutes ?? 15,
+        xpReward: data.xpReward ?? 50,
+        content,
+        metadata,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as PrismaLesson;
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          operation: 'lesson_entity_creation_success',
+          slug: data.slug,
+          title: data.title,
+          unitId: data.unitId,
+          lessonType: data.lessonType,
+          processingTime,
+        },
+        'Lesson entity created successfully'
+      );
+
+      return new LessonEntity(props);
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          operation: 'lesson_entity_creation_failed',
+          slug: data.slug,
+          title: data.title,
+          unitId: data.unitId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+          processingTime,
+        },
+        'Failed to create lesson entity'
+      );
+
+      throw error;
+    }
+  }
+
+  static fromPrisma(lesson: PrismaLesson): LessonEntity {
+    logger.debug(
+      {
+        operation: 'lesson_entity_from_prisma',
+        lessonId: lesson.id,
+        slug: lesson.slug,
+        title: lesson.title,
+        unitId: lesson.unitId,
+        lessonType: lesson.lessonType,
+        isPublished: lesson.isPublished,
+      },
+      'Creating lesson entity from Prisma model'
+    );
+
+    try {
+      return new LessonEntity(lesson);
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'lesson_entity_from_prisma_failed',
+          lessonId: lesson.id,
+          slug: lesson.slug,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to create lesson entity from Prisma model'
+      );
+      throw error;
+    }
+  }
+
+  // Getters
+  get id(): string {
+    return this.props.id;
+  }
+
+  get unitId(): string {
+    return this.props.unitId;
+  }
+
+  get slug(): string {
+    return this.props.slug;
+  }
+
+  get title(): string {
+    return this.props.title;
+  }
+
+  get description(): string {
+    return this.props.description;
+  }
+
+  get icon(): string | null {
+    return this.props.icon;
+  }
+
+  get order(): number {
+    return this.props.order;
+  }
+
+  get isPublished(): boolean {
+    return this.props.isPublished;
+  }
+
+  get lessonType(): LessonType {
+    return this.props.lessonType as LessonType;
+  }
+
+  get estimatedMinutes(): number {
+    return this.props.estimatedMinutes;
+  }
+
+  get xpReward(): number {
+    return this.props.xpReward;
+  }
+
+  get content(): LessonContent | null {
+    if (!this.props.content) return null;
+
+    try {
+      return typeof this.props.content === 'string'
+        ? JSON.parse(this.props.content)
+        : this.props.content;
+    } catch {
+      return null;
+    }
+  }
+
+  get metadata(): LessonMetadata {
+    try {
+      return typeof this.props.metadata === 'string'
+        ? JSON.parse(this.props.metadata)
+        : this.props.metadata;
+    } catch {
+      return {};
+    }
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this.props.updatedAt;
+  }
+
+  // Business logic methods
+  isTheory(): boolean {
+    return this.lessonType === LessonType.THEORY;
+  }
+
+  isPractical(): boolean {
+    return [
+      LessonType.PRACTICE,
+      LessonType.CHALLENGE,
+      LessonType.PROJECT,
+    ].includes(this.lessonType);
+  }
+
+  isQuiz(): boolean {
+    return this.lessonType === LessonType.QUIZ;
+  }
+
+  isVisible(): boolean {
+    return this.isPublished;
+  }
+
+  requiresCompletion(): boolean {
+    // Theory lessons can be marked as read/completed
+    // Practical lessons require challenge completion
+    return this.isPractical();
+  }
+
+  getEstimatedTimeRange(): { min: number; max: number } {
+    // Return time range based on lesson type
+    const baseTime = this.estimatedMinutes;
+
+    if (this.isTheory()) {
+      return { min: baseTime, max: baseTime };
+    }
+
+    if (this.isQuiz()) {
+      return { min: baseTime * 0.8, max: baseTime * 1.2 };
+    }
+
+    // Practical lessons have more variability
+    return { min: baseTime * 0.7, max: baseTime * 1.5 };
+  }
+
+  // Serialization
+  toJSON() {
+    return {
+      id: this.id,
+      unitId: this.unitId,
+      slug: this.slug,
+      title: this.title,
+      description: this.description,
+      icon: this.icon,
+      order: this.order,
+      isPublished: this.isPublished,
+      lessonType: this.lessonType,
+      estimatedMinutes: this.estimatedMinutes,
+      xpReward: this.xpReward,
+      content: this.content,
+      metadata: this.metadata,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  toPrisma(): PrismaLesson {
+    return this.props;
+  }
+}

--- a/src/modules/learning-paths/domain/entities/path.entity.ts
+++ b/src/modules/learning-paths/domain/entities/path.entity.ts
@@ -1,0 +1,224 @@
+import { LearningPath as PrismaLearningPath, Category, UserRole } from '@prisma/client';
+import { CreatePathDTO } from '../schemas/learning-path.schema';
+import { PathMetadata } from '../types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class PathEntity {
+  private constructor(private readonly props: PrismaLearningPath) {}
+
+  static create(data: CreatePathDTO): PathEntity {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        operation: 'path_entity_creation',
+        slug: data.slug,
+        title: data.title,
+        category: data.category,
+        targetRole: data.targetRole,
+        estimatedHours: data.estimatedHours,
+        totalXp: data.totalXp,
+        isPublished: data.isPublished,
+        order: data.order,
+      },
+      'Creating path entity'
+    );
+
+    try {
+      const metadata = typeof data.metadata === 'string'
+        ? data.metadata
+        : JSON.stringify(data.metadata || {});
+
+      const props = {
+        id: '', // Will be set by Prisma
+        slug: data.slug,
+        title: data.title,
+        description: data.description,
+        icon: data.icon || null,
+        color: data.color || null,
+        order: data.order ?? 0,
+        isPublished: data.isPublished ?? false,
+        category: data.category,
+        targetRole: data.targetRole || null,
+        estimatedHours: data.estimatedHours ?? 0,
+        totalXp: data.totalXp ?? 0,
+        metadata,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as PrismaLearningPath;
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          operation: 'path_entity_creation_success',
+          slug: data.slug,
+          title: data.title,
+          category: data.category,
+          processingTime,
+        },
+        'Path entity created successfully'
+      );
+
+      return new PathEntity(props);
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          operation: 'path_entity_creation_failed',
+          slug: data.slug,
+          title: data.title,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+          processingTime,
+        },
+        'Failed to create path entity'
+      );
+
+      throw error;
+    }
+  }
+
+  static fromPrisma(path: PrismaLearningPath): PathEntity {
+    logger.debug(
+      {
+        operation: 'path_entity_from_prisma',
+        pathId: path.id,
+        slug: path.slug,
+        title: path.title,
+        category: path.category,
+        isPublished: path.isPublished,
+      },
+      'Creating path entity from Prisma model'
+    );
+
+    try {
+      return new PathEntity(path);
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'path_entity_from_prisma_failed',
+          pathId: path.id,
+          slug: path.slug,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to create path entity from Prisma model'
+      );
+      throw error;
+    }
+  }
+
+  // Getters
+  get id(): string {
+    return this.props.id;
+  }
+
+  get slug(): string {
+    return this.props.slug;
+  }
+
+  get title(): string {
+    return this.props.title;
+  }
+
+  get description(): string {
+    return this.props.description;
+  }
+
+  get icon(): string | null {
+    return this.props.icon;
+  }
+
+  get color(): string | null {
+    return this.props.color;
+  }
+
+  get order(): number {
+    return this.props.order;
+  }
+
+  get isPublished(): boolean {
+    return this.props.isPublished;
+  }
+
+  get category(): Category {
+    return this.props.category;
+  }
+
+  get targetRole(): UserRole | null {
+    return this.props.targetRole;
+  }
+
+  get estimatedHours(): number {
+    return this.props.estimatedHours;
+  }
+
+  get totalXp(): number {
+    return this.props.totalXp;
+  }
+
+  get metadata(): PathMetadata {
+    try {
+      return typeof this.props.metadata === 'string'
+        ? JSON.parse(this.props.metadata)
+        : this.props.metadata;
+    } catch {
+      return {};
+    }
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this.props.updatedAt;
+  }
+
+  // Business logic methods
+  canBeAccessedByRole(userRole: UserRole): boolean {
+    if (!this.targetRole) {
+      return true; // No role restriction
+    }
+
+    const roleHierarchy: Record<UserRole, number> = {
+      JUNIOR: 1,
+      PLENO: 2,
+      SENIOR: 3,
+      TECH_LEAD: 4,
+      ARCHITECT: 5,
+    };
+
+    return roleHierarchy[userRole] >= roleHierarchy[this.targetRole];
+  }
+
+  isVisible(): boolean {
+    return this.isPublished;
+  }
+
+  // Serialization
+  toJSON() {
+    return {
+      id: this.id,
+      slug: this.slug,
+      title: this.title,
+      description: this.description,
+      icon: this.icon,
+      color: this.color,
+      order: this.order,
+      isPublished: this.isPublished,
+      category: this.category,
+      targetRole: this.targetRole,
+      estimatedHours: this.estimatedHours,
+      totalXp: this.totalXp,
+      metadata: this.metadata,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  toPrisma(): PrismaLearningPath {
+    return this.props;
+  }
+}

--- a/src/modules/learning-paths/domain/entities/unit.entity.ts
+++ b/src/modules/learning-paths/domain/entities/unit.entity.ts
@@ -1,0 +1,229 @@
+import { LearningUnit as PrismaLearningUnit } from '@prisma/client';
+import { CreateUnitDTO } from '../schemas/learning-path.schema';
+import { UnitMetadata } from '../types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class UnitEntity {
+  private constructor(private readonly props: PrismaLearningUnit) {}
+
+  static create(data: CreateUnitDTO): UnitEntity {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        operation: 'unit_entity_creation',
+        slug: data.slug,
+        title: data.title,
+        pathId: data.pathId,
+        estimatedHours: data.estimatedHours,
+        totalXp: data.totalXp,
+        isPublished: data.isPublished,
+        order: data.order,
+        prerequisitesCount: data.prerequisites?.length || 0,
+        learningGoalsCount: data.learningGoals?.length || 0,
+      },
+      'Creating unit entity'
+    );
+
+    try {
+      const metadata = typeof data.metadata === 'string'
+        ? data.metadata
+        : JSON.stringify(data.metadata || {});
+
+      const props = {
+        id: '', // Will be set by Prisma
+        pathId: data.pathId,
+        slug: data.slug,
+        title: data.title,
+        description: data.description,
+        icon: data.icon || null,
+        order: data.order ?? 0,
+        isPublished: data.isPublished ?? false,
+        estimatedHours: data.estimatedHours ?? 0,
+        totalXp: data.totalXp ?? 0,
+        prerequisites: data.prerequisites || [],
+        learningGoals: data.learningGoals || [],
+        metadata,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as PrismaLearningUnit;
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          operation: 'unit_entity_creation_success',
+          slug: data.slug,
+          title: data.title,
+          pathId: data.pathId,
+          processingTime,
+        },
+        'Unit entity created successfully'
+      );
+
+      return new UnitEntity(props);
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          operation: 'unit_entity_creation_failed',
+          slug: data.slug,
+          title: data.title,
+          pathId: data.pathId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+          processingTime,
+        },
+        'Failed to create unit entity'
+      );
+
+      throw error;
+    }
+  }
+
+  static fromPrisma(unit: PrismaLearningUnit): UnitEntity {
+    logger.debug(
+      {
+        operation: 'unit_entity_from_prisma',
+        unitId: unit.id,
+        slug: unit.slug,
+        title: unit.title,
+        pathId: unit.pathId,
+        isPublished: unit.isPublished,
+      },
+      'Creating unit entity from Prisma model'
+    );
+
+    try {
+      return new UnitEntity(unit);
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'unit_entity_from_prisma_failed',
+          unitId: unit.id,
+          slug: unit.slug,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to create unit entity from Prisma model'
+      );
+      throw error;
+    }
+  }
+
+  // Getters
+  get id(): string {
+    return this.props.id;
+  }
+
+  get pathId(): string {
+    return this.props.pathId;
+  }
+
+  get slug(): string {
+    return this.props.slug;
+  }
+
+  get title(): string {
+    return this.props.title;
+  }
+
+  get description(): string {
+    return this.props.description;
+  }
+
+  get icon(): string | null {
+    return this.props.icon;
+  }
+
+  get order(): number {
+    return this.props.order;
+  }
+
+  get isPublished(): boolean {
+    return this.props.isPublished;
+  }
+
+  get estimatedHours(): number {
+    return this.props.estimatedHours;
+  }
+
+  get totalXp(): number {
+    return this.props.totalXp;
+  }
+
+  get prerequisites(): string[] {
+    return this.props.prerequisites;
+  }
+
+  get learningGoals(): string[] {
+    return this.props.learningGoals;
+  }
+
+  get metadata(): UnitMetadata {
+    try {
+      return typeof this.props.metadata === 'string'
+        ? JSON.parse(this.props.metadata)
+        : this.props.metadata;
+    } catch {
+      return {};
+    }
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this.props.updatedAt;
+  }
+
+  // Business logic methods
+  hasPrerequisites(): boolean {
+    return this.prerequisites.length > 0;
+  }
+
+  isPrerequisiteSatisfied(completedUnitIds: string[]): boolean {
+    if (!this.hasPrerequisites()) {
+      return true;
+    }
+
+    return this.prerequisites.every((prereqId) =>
+      completedUnitIds.includes(prereqId)
+    );
+  }
+
+  isVisible(): boolean {
+    return this.isPublished;
+  }
+
+  getProgress(completedLessonCount: number, totalLessonCount: number): number {
+    if (totalLessonCount === 0) return 0;
+    return Math.round((completedLessonCount / totalLessonCount) * 100);
+  }
+
+  // Serialization
+  toJSON() {
+    return {
+      id: this.id,
+      pathId: this.pathId,
+      slug: this.slug,
+      title: this.title,
+      description: this.description,
+      icon: this.icon,
+      order: this.order,
+      isPublished: this.isPublished,
+      estimatedHours: this.estimatedHours,
+      totalXp: this.totalXp,
+      prerequisites: this.prerequisites,
+      learningGoals: this.learningGoals,
+      metadata: this.metadata,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  toPrisma(): PrismaLearningUnit {
+    return this.props;
+  }
+}

--- a/src/modules/learning-paths/domain/errors/index.ts
+++ b/src/modules/learning-paths/domain/errors/index.ts
@@ -1,0 +1,7 @@
+export * from './learning-path.error';
+export * from './path-not-found.error';
+export * from './path-slug-exists.error';
+export * from './unit-not-found.error';
+export * from './unit-slug-exists.error';
+export * from './lesson-not-found.error';
+export * from './lesson-slug-exists.error';

--- a/src/modules/learning-paths/domain/errors/learning-path.error.ts
+++ b/src/modules/learning-paths/domain/errors/learning-path.error.ts
@@ -1,0 +1,8 @@
+import { DomainError } from '@/shared/domain/errors/domain.error';
+
+export class LearningPathError extends DomainError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, details);
+    this.name = 'LearningPathError';
+  }
+}

--- a/src/modules/learning-paths/domain/errors/lesson-not-found.error.ts
+++ b/src/modules/learning-paths/domain/errors/lesson-not-found.error.ts
@@ -1,0 +1,8 @@
+import { LearningPathError } from './learning-path.error';
+
+export class LessonNotFoundError extends LearningPathError {
+  constructor(identifier: string) {
+    super(`Lesson not found: ${identifier}`, { identifier });
+    this.name = 'LessonNotFoundError';
+  }
+}

--- a/src/modules/learning-paths/domain/errors/lesson-slug-exists.error.ts
+++ b/src/modules/learning-paths/domain/errors/lesson-slug-exists.error.ts
@@ -1,0 +1,8 @@
+import { LearningPathError } from './learning-path.error';
+
+export class LessonSlugExistsError extends LearningPathError {
+  constructor(slug: string) {
+    super(`Lesson with slug '${slug}' already exists`, { slug });
+    this.name = 'LessonSlugExistsError';
+  }
+}

--- a/src/modules/learning-paths/domain/errors/path-not-found.error.ts
+++ b/src/modules/learning-paths/domain/errors/path-not-found.error.ts
@@ -1,0 +1,8 @@
+import { LearningPathError } from './learning-path.error';
+
+export class PathNotFoundError extends LearningPathError {
+  constructor(identifier: string) {
+    super(`Path not found: ${identifier}`, { identifier });
+    this.name = 'PathNotFoundError';
+  }
+}

--- a/src/modules/learning-paths/domain/errors/path-slug-exists.error.ts
+++ b/src/modules/learning-paths/domain/errors/path-slug-exists.error.ts
@@ -1,0 +1,8 @@
+import { LearningPathError } from './learning-path.error';
+
+export class PathSlugExistsError extends LearningPathError {
+  constructor(slug: string) {
+    super(`Path with slug '${slug}' already exists`, { slug });
+    this.name = 'PathSlugExistsError';
+  }
+}

--- a/src/modules/learning-paths/domain/errors/unit-not-found.error.ts
+++ b/src/modules/learning-paths/domain/errors/unit-not-found.error.ts
@@ -1,0 +1,8 @@
+import { LearningPathError } from './learning-path.error';
+
+export class UnitNotFoundError extends LearningPathError {
+  constructor(identifier: string) {
+    super(`Unit not found: ${identifier}`, { identifier });
+    this.name = 'UnitNotFoundError';
+  }
+}

--- a/src/modules/learning-paths/domain/errors/unit-slug-exists.error.ts
+++ b/src/modules/learning-paths/domain/errors/unit-slug-exists.error.ts
@@ -1,0 +1,8 @@
+import { LearningPathError } from './learning-path.error';
+
+export class UnitSlugExistsError extends LearningPathError {
+  constructor(slug: string) {
+    super(`Unit with slug '${slug}' already exists`, { slug });
+    this.name = 'UnitSlugExistsError';
+  }
+}

--- a/src/modules/learning-paths/domain/repositories/index.ts
+++ b/src/modules/learning-paths/domain/repositories/index.ts
@@ -1,0 +1,3 @@
+export * from './path.repository.interface';
+export * from './unit.repository.interface';
+export * from './lesson.repository.interface';

--- a/src/modules/learning-paths/domain/repositories/lesson.repository.interface.ts
+++ b/src/modules/learning-paths/domain/repositories/lesson.repository.interface.ts
@@ -1,0 +1,16 @@
+import { Lesson } from '@prisma/client';
+import { CreateLessonDTO, UpdateLessonDTO, LessonQueryDTO } from '../schemas/learning-path.schema';
+import { LessonWithRelations } from '../types/learning-path.types';
+
+export interface ILessonRepository {
+  create(data: CreateLessonDTO): Promise<Lesson>;
+  findById(id: string, includeChallenges?: boolean): Promise<LessonWithRelations | null>;
+  findBySlug(slug: string, includeChallenges?: boolean): Promise<LessonWithRelations | null>;
+  findAll(filters?: LessonQueryDTO): Promise<LessonWithRelations[]>;
+  findByUnitId(unitId: string, includeUnpublished?: boolean): Promise<LessonWithRelations[]>;
+  update(id: string, data: UpdateLessonDTO): Promise<Lesson>;
+  delete(id: string): Promise<void>;
+  count(filters?: Omit<LessonQueryDTO, 'page' | 'limit'>): Promise<number>;
+  existsBySlug(slug: string, excludeId?: string): Promise<boolean>;
+  reorder(unitId: string, lessonOrders: Array<{ id: string; order: number }>): Promise<void>;
+}

--- a/src/modules/learning-paths/domain/repositories/path.repository.interface.ts
+++ b/src/modules/learning-paths/domain/repositories/path.repository.interface.ts
@@ -1,0 +1,14 @@
+import { Path } from '@prisma/client';
+import { CreatePathDTO, UpdatePathDTO, PathQueryDTO } from '../schemas/learning-path.schema';
+import { PathWithRelations } from '../types/learning-path.types';
+
+export interface IPathRepository {
+  create(data: CreatePathDTO): Promise<Path>;
+  findById(id: string, includeUnits?: boolean): Promise<PathWithRelations | null>;
+  findBySlug(slug: string, includeUnits?: boolean): Promise<PathWithRelations | null>;
+  findAll(filters?: PathQueryDTO): Promise<PathWithRelations[]>;
+  update(id: string, data: UpdatePathDTO): Promise<Path>;
+  delete(id: string): Promise<void>;
+  count(filters?: Omit<PathQueryDTO, 'page' | 'limit'>): Promise<number>;
+  existsBySlug(slug: string, excludeId?: string): Promise<boolean>;
+}

--- a/src/modules/learning-paths/domain/repositories/unit.repository.interface.ts
+++ b/src/modules/learning-paths/domain/repositories/unit.repository.interface.ts
@@ -1,0 +1,16 @@
+import { Unit } from '@prisma/client';
+import { CreateUnitDTO, UpdateUnitDTO, UnitQueryDTO } from '../schemas/learning-path.schema';
+import { UnitWithRelations } from '../types/learning-path.types';
+
+export interface IUnitRepository {
+  create(data: CreateUnitDTO): Promise<Unit>;
+  findById(id: string, includeLessons?: boolean): Promise<UnitWithRelations | null>;
+  findBySlug(slug: string, includeLessons?: boolean): Promise<UnitWithRelations | null>;
+  findAll(filters?: UnitQueryDTO): Promise<UnitWithRelations[]>;
+  findByPathId(pathId: string, includeUnpublished?: boolean): Promise<UnitWithRelations[]>;
+  update(id: string, data: UpdateUnitDTO): Promise<Unit>;
+  delete(id: string): Promise<void>;
+  count(filters?: Omit<UnitQueryDTO, 'page' | 'limit'>): Promise<number>;
+  existsBySlug(slug: string, excludeId?: string): Promise<boolean>;
+  reorder(pathId: string, unitOrders: Array<{ id: string; order: number }>): Promise<void>;
+}

--- a/src/modules/learning-paths/domain/schemas/learning-path.schema.ts
+++ b/src/modules/learning-paths/domain/schemas/learning-path.schema.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+import { Category, UserRole } from '@prisma/client';
+
+export const LessonTypeEnum = z.enum(['THEORY', 'PRACTICE', 'QUIZ', 'PROJECT', 'CHALLENGE']);
+
+// Path Schemas
+export const CreatePathSchema = z.object({
+  slug: z.string().min(3).max(100).regex(/^[a-z0-9-]+$/, 'Slug must contain only lowercase letters, numbers, and hyphens'),
+  title: z.string().min(3).max(200),
+  description: z.string().min(10).max(2000),
+  icon: z.string().optional(),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/, 'Color must be a valid hex color').optional(),
+  order: z.number().int().min(0).default(0),
+  isPublished: z.boolean().default(false),
+  category: z.nativeEnum(Category),
+  targetRole: z.nativeEnum(UserRole).optional(),
+  estimatedHours: z.number().int().min(0).default(0),
+  totalXp: z.number().int().min(0).default(0),
+  metadata: z.record(z.unknown()).default({}),
+});
+
+export const UpdatePathSchema = CreatePathSchema.partial().omit({ slug: true });
+
+export const PathQuerySchema = z.object({
+  category: z.nativeEnum(Category).optional(),
+  isPublished: z.boolean().optional(),
+  targetRole: z.nativeEnum(UserRole).optional(),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+// Unit Schemas
+export const CreateUnitSchema = z.object({
+  pathId: z.string().cuid(),
+  slug: z.string().min(3).max(100).regex(/^[a-z0-9-]+$/, 'Slug must contain only lowercase letters, numbers, and hyphens'),
+  title: z.string().min(3).max(200),
+  description: z.string().min(10).max(2000),
+  icon: z.string().optional(),
+  order: z.number().int().min(0).default(0),
+  isPublished: z.boolean().default(false),
+  estimatedHours: z.number().int().min(0).default(0),
+  totalXp: z.number().int().min(0).default(0),
+  prerequisites: z.array(z.string()).default([]),
+  learningGoals: z.array(z.string()).default([]),
+  metadata: z.record(z.unknown()).default({}),
+});
+
+export const UpdateUnitSchema = CreateUnitSchema.partial().omit({ slug: true, pathId: true });
+
+export const UnitQuerySchema = z.object({
+  pathId: z.string().cuid().optional(),
+  isPublished: z.boolean().optional(),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+// Lesson Schemas
+export const CreateLessonSchema = z.object({
+  unitId: z.string().cuid(),
+  slug: z.string().min(3).max(100).regex(/^[a-z0-9-]+$/, 'Slug must contain only lowercase letters, numbers, and hyphens'),
+  title: z.string().min(3).max(200),
+  description: z.string().min(10).max(2000),
+  icon: z.string().optional(),
+  order: z.number().int().min(0).default(0),
+  isPublished: z.boolean().default(false),
+  lessonType: LessonTypeEnum.default('PRACTICE'),
+  estimatedMinutes: z.number().int().min(1).max(240).default(15),
+  xpReward: z.number().int().min(0).default(50),
+  content: z.record(z.unknown()).optional(),
+  metadata: z.record(z.unknown()).default({}),
+});
+
+export const UpdateLessonSchema = CreateLessonSchema.partial().omit({ slug: true, unitId: true });
+
+export const LessonQuerySchema = z.object({
+  unitId: z.string().cuid().optional(),
+  lessonType: LessonTypeEnum.optional(),
+  isPublished: z.boolean().optional(),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(20),
+});
+
+// Export types
+export type CreatePathDTO = z.infer<typeof CreatePathSchema>;
+export type UpdatePathDTO = z.infer<typeof UpdatePathSchema>;
+export type PathQueryDTO = z.infer<typeof PathQuerySchema>;
+
+export type CreateUnitDTO = z.infer<typeof CreateUnitSchema>;
+export type UpdateUnitDTO = z.infer<typeof UpdateUnitSchema>;
+export type UnitQueryDTO = z.infer<typeof UnitQuerySchema>;
+
+export type CreateLessonDTO = z.infer<typeof CreateLessonSchema>;
+export type UpdateLessonDTO = z.infer<typeof UpdateLessonSchema>;
+export type LessonQueryDTO = z.infer<typeof LessonQuerySchema>;

--- a/src/modules/learning-paths/domain/types/learning-path.types.ts
+++ b/src/modules/learning-paths/domain/types/learning-path.types.ts
@@ -1,0 +1,152 @@
+import { Category, UserRole } from '@prisma/client';
+
+export enum LessonType {
+  THEORY = 'THEORY',
+  PRACTICE = 'PRACTICE',
+  QUIZ = 'QUIZ',
+  PROJECT = 'PROJECT',
+  CHALLENGE = 'CHALLENGE',
+}
+
+export interface PathMetadata {
+  tags?: string[];
+  prerequisites?: string[];
+  outcomes?: string[];
+  [key: string]: unknown;
+}
+
+export interface UnitMetadata {
+  resources?: string[];
+  estimatedDifficulty?: 'BEGINNER' | 'INTERMEDIATE' | 'ADVANCED';
+  [key: string]: unknown;
+}
+
+export interface LessonMetadata {
+  videoUrl?: string;
+  readingTime?: number;
+  resources?: string[];
+  [key: string]: unknown;
+}
+
+export interface LessonContent {
+  sections?: Array<{
+    type: 'text' | 'code' | 'video' | 'quiz';
+    content: string;
+    language?: string;
+  }>;
+  summary?: string;
+  [key: string]: unknown;
+}
+
+export interface CreatePathData {
+  slug: string;
+  title: string;
+  description: string;
+  icon?: string;
+  color?: string;
+  order?: number;
+  isPublished?: boolean;
+  category: Category;
+  targetRole?: UserRole;
+  estimatedHours?: number;
+  totalXp?: number;
+  metadata?: PathMetadata;
+}
+
+export interface CreateUnitData {
+  pathId: string;
+  slug: string;
+  title: string;
+  description: string;
+  icon?: string;
+  order?: number;
+  isPublished?: boolean;
+  estimatedHours?: number;
+  totalXp?: number;
+  prerequisites?: string[];
+  learningGoals?: string[];
+  metadata?: UnitMetadata;
+}
+
+export interface CreateLessonData {
+  unitId: string;
+  slug: string;
+  title: string;
+  description: string;
+  icon?: string;
+  order?: number;
+  isPublished?: boolean;
+  lessonType?: LessonType;
+  estimatedMinutes?: number;
+  xpReward?: number;
+  content?: LessonContent;
+  metadata?: LessonMetadata;
+}
+
+export interface PathWithRelations {
+  id: string;
+  slug: string;
+  title: string;
+  description: string;
+  icon?: string;
+  color?: string;
+  order: number;
+  isPublished: boolean;
+  category: Category;
+  targetRole?: UserRole;
+  estimatedHours: number;
+  totalXp: number;
+  metadata: PathMetadata;
+  createdAt: Date;
+  updatedAt: Date;
+  units?: UnitWithRelations[];
+  _count?: {
+    units: number;
+  };
+}
+
+export interface UnitWithRelations {
+  id: string;
+  pathId: string;
+  slug: string;
+  title: string;
+  description: string;
+  icon?: string;
+  order: number;
+  isPublished: boolean;
+  estimatedHours: number;
+  totalXp: number;
+  prerequisites: string[];
+  learningGoals: string[];
+  metadata: UnitMetadata;
+  createdAt: Date;
+  updatedAt: Date;
+  path?: PathWithRelations;
+  lessons?: LessonWithRelations[];
+  _count?: {
+    lessons: number;
+  };
+}
+
+export interface LessonWithRelations {
+  id: string;
+  unitId: string;
+  slug: string;
+  title: string;
+  description: string;
+  icon?: string;
+  order: number;
+  isPublished: boolean;
+  lessonType: LessonType;
+  estimatedMinutes: number;
+  xpReward: number;
+  content?: LessonContent;
+  metadata: LessonMetadata;
+  createdAt: Date;
+  updatedAt: Date;
+  unit?: UnitWithRelations;
+  challenges?: unknown[];
+  _count?: {
+    challenges: number;
+  };
+}

--- a/src/modules/learning-paths/infrastructure/plugin/learning-path.plugin.ts
+++ b/src/modules/learning-paths/infrastructure/plugin/learning-path.plugin.ts
@@ -1,0 +1,92 @@
+import fp from 'fastify-plugin';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import { PrismaClient } from '@prisma/client';
+
+// Repositories
+import { PathRepository } from '../repositories/path.repository';
+import { UnitRepository } from '../repositories/unit.repository';
+import { LessonRepository } from '../repositories/lesson.repository';
+
+// Use Cases
+import {
+  CreatePathUseCase,
+  GetPathUseCase,
+  ListPathsUseCase,
+  CreateUnitUseCase,
+  GetUnitUseCase,
+  ListUnitsUseCase,
+  CreateLessonUseCase,
+  GetLessonUseCase,
+  ListLessonsUseCase,
+} from '../../application/use-cases';
+
+// Controllers
+import { PathController, UnitController, LessonController } from '../../presentation/controllers';
+
+// Routes
+import { learningPathRoutes } from '../../presentation/routes/learning-path.routes';
+
+export interface LearningPathPluginOptions {
+  prisma: PrismaClient;
+}
+
+const learningPathPlugin: FastifyPluginAsync<LearningPathPluginOptions> = async function (
+  fastify: FastifyInstance,
+  options: LearningPathPluginOptions
+): Promise<void> {
+  // Initialize repositories
+  const pathRepository = new PathRepository(options.prisma);
+  const unitRepository = new UnitRepository(options.prisma);
+  const lessonRepository = new LessonRepository(options.prisma);
+
+  // Initialize Path use cases
+  const createPathUseCase = new CreatePathUseCase(pathRepository);
+  const getPathUseCase = new GetPathUseCase(pathRepository);
+  const listPathsUseCase = new ListPathsUseCase(pathRepository);
+
+  // Initialize Unit use cases
+  const createUnitUseCase = new CreateUnitUseCase(unitRepository, pathRepository);
+  const getUnitUseCase = new GetUnitUseCase(unitRepository);
+  const listUnitsUseCase = new ListUnitsUseCase(unitRepository);
+
+  // Initialize Lesson use cases
+  const createLessonUseCase = new CreateLessonUseCase(lessonRepository, unitRepository);
+  const getLessonUseCase = new GetLessonUseCase(lessonRepository);
+  const listLessonsUseCase = new ListLessonsUseCase(lessonRepository);
+
+  // Initialize controllers
+  const pathController = new PathController(
+    createPathUseCase,
+    getPathUseCase,
+    listPathsUseCase
+  );
+
+  const unitController = new UnitController(
+    createUnitUseCase,
+    getUnitUseCase,
+    listUnitsUseCase
+  );
+
+  const lessonController = new LessonController(
+    createLessonUseCase,
+    getLessonUseCase,
+    listLessonsUseCase
+  );
+
+  // Register routes
+  await fastify.register(
+    async function learningPathRoutesPlugin(childInstance) {
+      await learningPathRoutes(childInstance, pathController, unitController, lessonController);
+    },
+    {
+      prefix: '/learning-paths',
+    }
+  );
+
+  fastify.log.info('Learning Path plugin registered successfully');
+};
+
+export default fp(learningPathPlugin, {
+  name: 'learning-path-plugin',
+  dependencies: ['auth-plugin'],
+});

--- a/src/modules/learning-paths/infrastructure/repositories/index.ts
+++ b/src/modules/learning-paths/infrastructure/repositories/index.ts
@@ -1,0 +1,3 @@
+export * from './path.repository';
+export * from './unit.repository';
+export * from './lesson.repository';

--- a/src/modules/learning-paths/infrastructure/repositories/lesson.repository.ts
+++ b/src/modules/learning-paths/infrastructure/repositories/lesson.repository.ts
@@ -1,0 +1,249 @@
+import { PrismaClient, Lesson } from '@prisma/client';
+import { ILessonRepository } from '../../domain/repositories/lesson.repository.interface';
+import { CreateLessonDTO, UpdateLessonDTO, LessonQueryDTO } from '../../domain/schemas/learning-path.schema';
+import { LessonEntity } from '../../domain/entities/lesson.entity';
+import { LessonWithRelations } from '../../domain/types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class LessonRepository implements ILessonRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(data: CreateLessonDTO): Promise<Lesson> {
+    const startTime = Date.now();
+
+    logger.info({ operation: 'create_lesson', slug: data.slug, title: data.title, unitId: data.unitId, lessonType: data.lessonType }, 'Creating new lesson');
+
+    try {
+      const entity = LessonEntity.create(data);
+      const prismaData = entity.toPrisma();
+
+      const lesson = await this.prisma.lesson.create({
+        data: {
+          unitId: prismaData.unitId,
+          slug: prismaData.slug,
+          title: prismaData.title,
+          description: prismaData.description,
+          icon: prismaData.icon,
+          order: prismaData.order,
+          isPublished: prismaData.isPublished,
+          lessonType: prismaData.lessonType,
+          estimatedMinutes: prismaData.estimatedMinutes,
+          xpReward: prismaData.xpReward,
+          content: prismaData.content,
+          metadata: prismaData.metadata || {},
+        },
+      });
+
+      const processingTime = Date.now() - startTime;
+      logger.info({ operation: 'create_lesson_success', lessonId: lesson.id, slug: lesson.slug, processingTime }, 'Lesson created successfully');
+
+      return lesson;
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+      logger.error({
+        operation: 'create_lesson_failed',
+        slug: data.slug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        processingTime,
+      }, 'Failed to create lesson');
+      throw error;
+    }
+  }
+
+  async findById(id: string, includeChallenges = false): Promise<LessonWithRelations | null> {
+    logger.debug({ operation: 'find_lesson_by_id', lessonId: id, includeChallenges }, 'Finding lesson by ID');
+
+    try {
+      const lesson = await this.prisma.lesson.findUnique({
+        where: { id },
+        include: includeChallenges
+          ? {
+              challenges: {
+                where: { isPublished: true },
+                orderBy: { order: 'asc' },
+              },
+              unit: {
+                include: { path: true },
+              },
+              _count: { select: { challenges: true } },
+            }
+          : {
+              unit: {
+                include: { path: true },
+              },
+              _count: { select: { challenges: true } },
+            },
+      });
+
+      return lesson as LessonWithRelations | null;
+    } catch (error) {
+      logger.error({ operation: 'find_lesson_by_id_failed', lessonId: id, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find lesson');
+      throw error;
+    }
+  }
+
+  async findBySlug(slug: string, includeChallenges = false): Promise<LessonWithRelations | null> {
+    logger.debug({ operation: 'find_lesson_by_slug', slug, includeChallenges }, 'Finding lesson by slug');
+
+    try {
+      const lesson = await this.prisma.lesson.findUnique({
+        where: { slug },
+        include: includeChallenges
+          ? {
+              challenges: {
+                where: { isPublished: true },
+                orderBy: { order: 'asc' },
+              },
+              unit: {
+                include: { path: true },
+              },
+              _count: { select: { challenges: true } },
+            }
+          : {
+              unit: {
+                include: { path: true },
+              },
+              _count: { select: { challenges: true } },
+            },
+      });
+
+      return lesson as LessonWithRelations | null;
+    } catch (error) {
+      logger.error({ operation: 'find_lesson_by_slug_failed', slug, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find lesson');
+      throw error;
+    }
+  }
+
+  async findAll(filters?: LessonQueryDTO): Promise<LessonWithRelations[]> {
+    logger.debug({ operation: 'find_all_lessons', filters }, 'Finding all lessons');
+
+    try {
+      const where: any = {};
+
+      if (filters?.unitId) where.unitId = filters.unitId;
+      if (filters?.lessonType) where.lessonType = filters.lessonType;
+      if (filters?.isPublished !== undefined) where.isPublished = filters.isPublished;
+
+      const page = filters?.page || 1;
+      const limit = filters?.limit || 20;
+      const skip = (page - 1) * limit;
+
+      const lessons = await this.prisma.lesson.findMany({
+        where,
+        include: {
+          unit: {
+            include: { path: true },
+          },
+          _count: { select: { challenges: true } },
+        },
+        orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
+        skip,
+        take: limit,
+      });
+
+      logger.info({ operation: 'find_all_lessons_success', count: lessons.length }, 'Lessons found');
+      return lessons as LessonWithRelations[];
+    } catch (error) {
+      logger.error({ operation: 'find_all_lessons_failed', error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find lessons');
+      throw error;
+    }
+  }
+
+  async findByUnitId(unitId: string, includeUnpublished = false): Promise<LessonWithRelations[]> {
+    logger.debug({ operation: 'find_lessons_by_unit', unitId, includeUnpublished }, 'Finding lessons by unit ID');
+
+    try {
+      const where: any = { unitId };
+      if (!includeUnpublished) where.isPublished = true;
+
+      const lessons = await this.prisma.lesson.findMany({
+        where,
+        include: {
+          _count: { select: { challenges: true } },
+        },
+        orderBy: { order: 'asc' },
+      });
+
+      return lessons as LessonWithRelations[];
+    } catch (error) {
+      logger.error({ operation: 'find_lessons_by_unit_failed', unitId, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find lessons by unit');
+      throw error;
+    }
+  }
+
+  async update(id: string, data: UpdateLessonDTO): Promise<Lesson> {
+    logger.info({ operation: 'update_lesson', lessonId: id, updates: Object.keys(data) }, 'Updating lesson');
+
+    try {
+      const lesson = await this.prisma.lesson.update({
+        where: { id },
+        data: data as any,
+      });
+
+      logger.info({ operation: 'update_lesson_success', lessonId: id }, 'Lesson updated successfully');
+      return lesson;
+    } catch (error) {
+      logger.error({ operation: 'update_lesson_failed', lessonId: id, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to update lesson');
+      throw error;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    logger.info({ operation: 'delete_lesson', lessonId: id }, 'Deleting lesson');
+
+    try {
+      await this.prisma.lesson.delete({ where: { id } });
+      logger.info({ operation: 'delete_lesson_success', lessonId: id }, 'Lesson deleted successfully');
+    } catch (error) {
+      logger.error({ operation: 'delete_lesson_failed', lessonId: id, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to delete lesson');
+      throw error;
+    }
+  }
+
+  async count(filters?: Omit<LessonQueryDTO, 'page' | 'limit'>): Promise<number> {
+    try {
+      const where: any = {};
+      if (filters?.unitId) where.unitId = filters.unitId;
+      if (filters?.lessonType) where.lessonType = filters.lessonType;
+      if (filters?.isPublished !== undefined) where.isPublished = filters.isPublished;
+
+      return await this.prisma.lesson.count({ where });
+    } catch (error) {
+      logger.error({ operation: 'count_lessons_failed', error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to count lessons');
+      throw error;
+    }
+  }
+
+  async existsBySlug(slug: string, excludeId?: string): Promise<boolean> {
+    try {
+      const where: any = { slug };
+      if (excludeId) where.id = { not: excludeId };
+
+      const count = await this.prisma.lesson.count({ where });
+      return count > 0;
+    } catch (error) {
+      logger.error({ operation: 'exists_by_slug_failed', slug, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to check lesson existence');
+      throw error;
+    }
+  }
+
+  async reorder(unitId: string, lessonOrders: Array<{ id: string; order: number }>): Promise<void> {
+    logger.info({ operation: 'reorder_lessons', unitId, count: lessonOrders.length }, 'Reordering lessons');
+
+    try {
+      await this.prisma.$transaction(
+        lessonOrders.map(({ id, order }) =>
+          this.prisma.lesson.update({
+            where: { id },
+            data: { order },
+          })
+        )
+      );
+
+      logger.info({ operation: 'reorder_lessons_success', unitId }, 'Lessons reordered successfully');
+    } catch (error) {
+      logger.error({ operation: 'reorder_lessons_failed', unitId, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to reorder lessons');
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/infrastructure/repositories/path.repository.ts
+++ b/src/modules/learning-paths/infrastructure/repositories/path.repository.ts
@@ -1,0 +1,444 @@
+import { PrismaClient, Path } from '@prisma/client';
+import { IPathRepository } from '../../domain/repositories/path.repository.interface';
+import { CreatePathDTO, UpdatePathDTO, PathQueryDTO } from '../../domain/schemas/learning-path.schema';
+import { PathEntity } from '../../domain/entities/path.entity';
+import { PathWithRelations } from '../../domain/types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class PathRepository implements IPathRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(data: CreatePathDTO): Promise<Path> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        operation: 'create_path',
+        slug: data.slug,
+        title: data.title,
+        category: data.category,
+        targetRole: data.targetRole,
+        estimatedHours: data.estimatedHours,
+      },
+      'Creating new path'
+    );
+
+    try {
+      const entity = PathEntity.create(data);
+      const prismaData = entity.toPrisma();
+
+      const path = await this.prisma.path.create({
+        data: {
+          slug: prismaData.slug,
+          title: prismaData.title,
+          description: prismaData.description,
+          icon: prismaData.icon,
+          color: prismaData.color,
+          order: prismaData.order,
+          isPublished: prismaData.isPublished,
+          category: prismaData.category,
+          targetRole: prismaData.targetRole,
+          estimatedHours: prismaData.estimatedHours,
+          totalXp: prismaData.totalXp,
+          metadata: prismaData.metadata || {},
+        },
+      });
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          operation: 'create_path_success',
+          pathId: path.id,
+          slug: path.slug,
+          title: path.title,
+          category: path.category,
+          processingTime,
+        },
+        'Path created successfully'
+      );
+
+      return path;
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          operation: 'create_path_failed',
+          slug: data.slug,
+          title: data.title,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+          processingTime,
+        },
+        'Failed to create path'
+      );
+
+      throw error;
+    }
+  }
+
+  async findById(id: string, includeUnits = false): Promise<PathWithRelations | null> {
+    const startTime = Date.now();
+
+    logger.debug(
+      {
+        operation: 'find_path_by_id',
+        pathId: id,
+        includeUnits,
+      },
+      'Finding path by ID'
+    );
+
+    try {
+      const path = await this.prisma.path.findUnique({
+        where: { id },
+        include: includeUnits
+          ? {
+              units: {
+                where: { isPublished: true },
+                orderBy: { order: 'asc' },
+                include: {
+                  _count: {
+                    select: { lessons: true },
+                  },
+                },
+              },
+              _count: {
+                select: { units: true },
+              },
+            }
+          : {
+              _count: {
+                select: { units: true },
+              },
+            },
+      });
+
+      const processingTime = Date.now() - startTime;
+
+      if (path) {
+        logger.debug(
+          {
+            operation: 'find_path_by_id_success',
+            pathId: id,
+            found: true,
+            processingTime,
+          },
+          'Path found'
+        );
+      } else {
+        logger.debug(
+          {
+            operation: 'find_path_by_id_not_found',
+            pathId: id,
+            found: false,
+            processingTime,
+          },
+          'Path not found'
+        );
+      }
+
+      return path as PathWithRelations | null;
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'find_path_by_id_failed',
+          pathId: id,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to find path by ID'
+      );
+      throw error;
+    }
+  }
+
+  async findBySlug(slug: string, includeUnits = false): Promise<PathWithRelations | null> {
+    const startTime = Date.now();
+
+    logger.debug(
+      {
+        operation: 'find_path_by_slug',
+        slug,
+        includeUnits,
+      },
+      'Finding path by slug'
+    );
+
+    try {
+      const path = await this.prisma.path.findUnique({
+        where: { slug },
+        include: includeUnits
+          ? {
+              units: {
+                where: { isPublished: true },
+                orderBy: { order: 'asc' },
+                include: {
+                  _count: {
+                    select: { lessons: true },
+                  },
+                },
+              },
+              _count: {
+                select: { units: true },
+              },
+            }
+          : {
+              _count: {
+                select: { units: true },
+              },
+            },
+      });
+
+      const processingTime = Date.now() - startTime;
+
+      logger.debug(
+        {
+          operation: 'find_path_by_slug_result',
+          slug,
+          found: !!path,
+          processingTime,
+        },
+        path ? 'Path found' : 'Path not found'
+      );
+
+      return path as PathWithRelations | null;
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'find_path_by_slug_failed',
+          slug,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to find path by slug'
+      );
+      throw error;
+    }
+  }
+
+  async findAll(filters?: PathQueryDTO): Promise<PathWithRelations[]> {
+    const startTime = Date.now();
+
+    logger.debug(
+      {
+        operation: 'find_all_paths',
+        filters,
+      },
+      'Finding all paths'
+    );
+
+    try {
+      const where: any = {};
+
+      if (filters?.category) {
+        where.category = filters.category;
+      }
+
+      if (filters?.isPublished !== undefined) {
+        where.isPublished = filters.isPublished;
+      }
+
+      if (filters?.targetRole) {
+        where.targetRole = filters.targetRole;
+      }
+
+      const page = filters?.page || 1;
+      const limit = filters?.limit || 20;
+      const skip = (page - 1) * limit;
+
+      const paths = await this.prisma.path.findMany({
+        where,
+        include: {
+          units: {
+            where: { isPublished: true },
+            orderBy: { order: 'asc' },
+            include: {
+              _count: {
+                select: { lessons: true },
+              },
+            },
+          },
+          _count: {
+            select: { units: true },
+          },
+        },
+        orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
+        skip,
+        take: limit,
+      });
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          operation: 'find_all_paths_success',
+          count: paths.length,
+          filters,
+          processingTime,
+        },
+        'Paths found'
+      );
+
+      return paths as PathWithRelations[];
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'find_all_paths_failed',
+          filters,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to find paths'
+      );
+      throw error;
+    }
+  }
+
+  async update(id: string, data: UpdatePathDTO): Promise<Path> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        operation: 'update_path',
+        pathId: id,
+        updates: Object.keys(data),
+      },
+      'Updating path'
+    );
+
+    try {
+      const updateData: any = { ...data };
+
+      if (data.metadata) {
+        updateData.metadata = data.metadata;
+      }
+
+      const path = await this.prisma.path.update({
+        where: { id },
+        data: updateData,
+      });
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          operation: 'update_path_success',
+          pathId: id,
+          processingTime,
+        },
+        'Path updated successfully'
+      );
+
+      return path;
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          operation: 'update_path_failed',
+          pathId: id,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to update path'
+      );
+
+      throw error;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    const startTime = Date.now();
+
+    logger.info(
+      {
+        operation: 'delete_path',
+        pathId: id,
+      },
+      'Deleting path'
+    );
+
+    try {
+      await this.prisma.path.delete({
+        where: { id },
+      });
+
+      const processingTime = Date.now() - startTime;
+
+      logger.info(
+        {
+          operation: 'delete_path_success',
+          pathId: id,
+          processingTime,
+        },
+        'Path deleted successfully'
+      );
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+
+      logger.error(
+        {
+          operation: 'delete_path_failed',
+          pathId: id,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          processingTime,
+        },
+        'Failed to delete path'
+      );
+
+      throw error;
+    }
+  }
+
+  async count(filters?: Omit<PathQueryDTO, 'page' | 'limit'>): Promise<number> {
+    try {
+      const where: any = {};
+
+      if (filters?.category) {
+        where.category = filters.category;
+      }
+
+      if (filters?.isPublished !== undefined) {
+        where.isPublished = filters.isPublished;
+      }
+
+      if (filters?.targetRole) {
+        where.targetRole = filters.targetRole;
+      }
+
+      return await this.prisma.path.count({ where });
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'count_paths_failed',
+          filters,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to count paths'
+      );
+      throw error;
+    }
+  }
+
+  async existsBySlug(slug: string, excludeId?: string): Promise<boolean> {
+    try {
+      const where: any = { slug };
+
+      if (excludeId) {
+        where.id = { not: excludeId };
+      }
+
+      const count = await this.prisma.path.count({ where });
+      return count > 0;
+    } catch (error) {
+      logger.error(
+        {
+          operation: 'exists_by_slug_failed',
+          slug,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to check path existence by slug'
+      );
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/infrastructure/repositories/unit.repository.ts
+++ b/src/modules/learning-paths/infrastructure/repositories/unit.repository.ts
@@ -1,0 +1,243 @@
+import { PrismaClient, Unit } from '@prisma/client';
+import { IUnitRepository } from '../../domain/repositories/unit.repository.interface';
+import { CreateUnitDTO, UpdateUnitDTO, UnitQueryDTO } from '../../domain/schemas/learning-path.schema';
+import { UnitEntity } from '../../domain/entities/unit.entity';
+import { UnitWithRelations } from '../../domain/types/learning-path.types';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+
+export class UnitRepository implements IUnitRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(data: CreateUnitDTO): Promise<Unit> {
+    const startTime = Date.now();
+
+    logger.info({ operation: 'create_unit', slug: data.slug, title: data.title, pathId: data.pathId }, 'Creating new unit');
+
+    try {
+      const entity = UnitEntity.create(data);
+      const prismaData = entity.toPrisma();
+
+      const unit = await this.prisma.unit.create({
+        data: {
+          pathId: prismaData.pathId,
+          slug: prismaData.slug,
+          title: prismaData.title,
+          description: prismaData.description,
+          icon: prismaData.icon,
+          order: prismaData.order,
+          isPublished: prismaData.isPublished,
+          estimatedHours: prismaData.estimatedHours,
+          totalXp: prismaData.totalXp,
+          prerequisites: prismaData.prerequisites,
+          learningGoals: prismaData.learningGoals,
+          metadata: prismaData.metadata || {},
+        },
+      });
+
+      const processingTime = Date.now() - startTime;
+      logger.info({ operation: 'create_unit_success', unitId: unit.id, slug: unit.slug, processingTime }, 'Unit created successfully');
+
+      return unit;
+    } catch (error) {
+      const processingTime = Date.now() - startTime;
+      logger.error({
+        operation: 'create_unit_failed',
+        slug: data.slug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        processingTime,
+      }, 'Failed to create unit');
+      throw error;
+    }
+  }
+
+  async findById(id: string, includeLessons = false): Promise<UnitWithRelations | null> {
+    logger.debug({ operation: 'find_unit_by_id', unitId: id, includeLessons }, 'Finding unit by ID');
+
+    try {
+      const unit = await this.prisma.unit.findUnique({
+        where: { id },
+        include: includeLessons
+          ? {
+              lessons: {
+                where: { isPublished: true },
+                orderBy: { order: 'asc' },
+                include: {
+                  _count: { select: { challenges: true } },
+                },
+              },
+              path: true,
+              _count: { select: { lessons: true } },
+            }
+          : {
+              path: true,
+              _count: { select: { lessons: true } },
+            },
+      });
+
+      return unit as UnitWithRelations | null;
+    } catch (error) {
+      logger.error({ operation: 'find_unit_by_id_failed', unitId: id, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find unit');
+      throw error;
+    }
+  }
+
+  async findBySlug(slug: string, includeLessons = false): Promise<UnitWithRelations | null> {
+    logger.debug({ operation: 'find_unit_by_slug', slug, includeLessons }, 'Finding unit by slug');
+
+    try {
+      const unit = await this.prisma.unit.findUnique({
+        where: { slug },
+        include: includeLessons
+          ? {
+              lessons: {
+                where: { isPublished: true },
+                orderBy: { order: 'asc' },
+                include: {
+                  _count: { select: { challenges: true } },
+                },
+              },
+              path: true,
+              _count: { select: { lessons: true } },
+            }
+          : {
+              path: true,
+              _count: { select: { lessons: true } },
+            },
+      });
+
+      return unit as UnitWithRelations | null;
+    } catch (error) {
+      logger.error({ operation: 'find_unit_by_slug_failed', slug, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find unit');
+      throw error;
+    }
+  }
+
+  async findAll(filters?: UnitQueryDTO): Promise<UnitWithRelations[]> {
+    logger.debug({ operation: 'find_all_units', filters }, 'Finding all units');
+
+    try {
+      const where: any = {};
+
+      if (filters?.pathId) where.pathId = filters.pathId;
+      if (filters?.isPublished !== undefined) where.isPublished = filters.isPublished;
+
+      const page = filters?.page || 1;
+      const limit = filters?.limit || 20;
+      const skip = (page - 1) * limit;
+
+      const units = await this.prisma.unit.findMany({
+        where,
+        include: {
+          path: true,
+          _count: { select: { lessons: true } },
+        },
+        orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
+        skip,
+        take: limit,
+      });
+
+      logger.info({ operation: 'find_all_units_success', count: units.length }, 'Units found');
+      return units as UnitWithRelations[];
+    } catch (error) {
+      logger.error({ operation: 'find_all_units_failed', error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find units');
+      throw error;
+    }
+  }
+
+  async findByPathId(pathId: string, includeUnpublished = false): Promise<UnitWithRelations[]> {
+    logger.debug({ operation: 'find_units_by_path', pathId, includeUnpublished }, 'Finding units by path ID');
+
+    try {
+      const where: any = { pathId };
+      if (!includeUnpublished) where.isPublished = true;
+
+      const units = await this.prisma.unit.findMany({
+        where,
+        include: {
+          _count: { select: { lessons: true } },
+        },
+        orderBy: { order: 'asc' },
+      });
+
+      return units as UnitWithRelations[];
+    } catch (error) {
+      logger.error({ operation: 'find_units_by_path_failed', pathId, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to find units by path');
+      throw error;
+    }
+  }
+
+  async update(id: string, data: UpdateUnitDTO): Promise<Unit> {
+    logger.info({ operation: 'update_unit', unitId: id, updates: Object.keys(data) }, 'Updating unit');
+
+    try {
+      const unit = await this.prisma.unit.update({
+        where: { id },
+        data: data as any,
+      });
+
+      logger.info({ operation: 'update_unit_success', unitId: id }, 'Unit updated successfully');
+      return unit;
+    } catch (error) {
+      logger.error({ operation: 'update_unit_failed', unitId: id, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to update unit');
+      throw error;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    logger.info({ operation: 'delete_unit', unitId: id }, 'Deleting unit');
+
+    try {
+      await this.prisma.unit.delete({ where: { id } });
+      logger.info({ operation: 'delete_unit_success', unitId: id }, 'Unit deleted successfully');
+    } catch (error) {
+      logger.error({ operation: 'delete_unit_failed', unitId: id, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to delete unit');
+      throw error;
+    }
+  }
+
+  async count(filters?: Omit<UnitQueryDTO, 'page' | 'limit'>): Promise<number> {
+    try {
+      const where: any = {};
+      if (filters?.pathId) where.pathId = filters.pathId;
+      if (filters?.isPublished !== undefined) where.isPublished = filters.isPublished;
+
+      return await this.prisma.unit.count({ where });
+    } catch (error) {
+      logger.error({ operation: 'count_units_failed', error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to count units');
+      throw error;
+    }
+  }
+
+  async existsBySlug(slug: string, excludeId?: string): Promise<boolean> {
+    try {
+      const where: any = { slug };
+      if (excludeId) where.id = { not: excludeId };
+
+      const count = await this.prisma.unit.count({ where });
+      return count > 0;
+    } catch (error) {
+      logger.error({ operation: 'exists_by_slug_failed', slug, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to check unit existence');
+      throw error;
+    }
+  }
+
+  async reorder(pathId: string, unitOrders: Array<{ id: string; order: number }>): Promise<void> {
+    logger.info({ operation: 'reorder_units', pathId, count: unitOrders.length }, 'Reordering units');
+
+    try {
+      await this.prisma.$transaction(
+        unitOrders.map(({ id, order }) =>
+          this.prisma.unit.update({
+            where: { id },
+            data: { order },
+          })
+        )
+      );
+
+      logger.info({ operation: 'reorder_units_success', pathId }, 'Units reordered successfully');
+    } catch (error) {
+      logger.error({ operation: 'reorder_units_failed', pathId, error: error instanceof Error ? error.message : 'Unknown error' }, 'Failed to reorder units');
+      throw error;
+    }
+  }
+}

--- a/src/modules/learning-paths/presentation/controllers/index.ts
+++ b/src/modules/learning-paths/presentation/controllers/index.ts
@@ -1,0 +1,3 @@
+export * from './path.controller';
+export * from './unit.controller';
+export * from './lesson.controller';

--- a/src/modules/learning-paths/presentation/controllers/lesson.controller.ts
+++ b/src/modules/learning-paths/presentation/controllers/lesson.controller.ts
@@ -1,0 +1,100 @@
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { CreateLessonUseCase, GetLessonUseCase, ListLessonsUseCase } from '../../application/use-cases';
+import { CreateLessonDTO, CreateLessonSchema, LessonQueryDTO, LessonQuerySchema } from '../../domain/schemas/learning-path.schema';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+import { LearningPathError } from '../../domain/errors';
+import { ZodError } from 'zod';
+
+export class LessonController {
+  constructor(
+    private readonly createLessonUseCase: CreateLessonUseCase,
+    private readonly getLessonUseCase: GetLessonUseCase,
+    private readonly listLessonsUseCase: ListLessonsUseCase
+  ) {}
+
+  createLesson = async (
+    request: FastifyRequest<{ Body: CreateLessonDTO }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    try {
+      const validatedData = CreateLessonSchema.parse(request.body);
+      const lesson = await this.createLessonUseCase.execute(validatedData);
+
+      return reply.status(201).send({
+        success: true,
+        data: lesson,
+      });
+    } catch (error) {
+      logger.error({
+        operation: 'create_lesson',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }, 'Failed to create lesson');
+
+      return this.handleError(error, reply);
+    }
+  };
+
+  getLesson = async (
+    request: FastifyRequest<{ Params: { identifier: string }; Querystring: { includeChallenges?: string } }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    const { identifier } = request.params;
+    const includeChallenges = request.query.includeChallenges === 'true';
+
+    try {
+      const lesson = await this.getLessonUseCase.execute(identifier, includeChallenges);
+
+      return reply.status(200).send({
+        success: true,
+        data: lesson,
+      });
+    } catch (error) {
+      return this.handleError(error, reply);
+    }
+  };
+
+  listLessons = async (
+    request: FastifyRequest<{ Querystring: LessonQueryDTO }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    try {
+      const filters = LessonQuerySchema.parse(request.query);
+      const result = await this.listLessonsUseCase.execute(filters);
+
+      return reply.status(200).send({
+        success: true,
+        data: result.lessons,
+        pagination: {
+          page: result.page,
+          limit: result.limit,
+          total: result.total,
+          totalPages: result.totalPages,
+        },
+      });
+    } catch (error) {
+      return this.handleError(error, reply);
+    }
+  };
+
+  private handleError(error: unknown, reply: FastifyReply): FastifyReply {
+    if (error instanceof ZodError) {
+      return reply.status(400).send({
+        success: false,
+        error: 'Validation error',
+        details: error.errors,
+      });
+    }
+
+    if (error instanceof LearningPathError) {
+      return reply.status(400).send({
+        success: false,
+        error: error.message,
+      });
+    }
+
+    return reply.status(500).send({
+      success: false,
+      error: 'Internal server error',
+    });
+  }
+}

--- a/src/modules/learning-paths/presentation/controllers/path.controller.ts
+++ b/src/modules/learning-paths/presentation/controllers/path.controller.ts
@@ -1,0 +1,137 @@
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { CreatePathUseCase, GetPathUseCase, ListPathsUseCase } from '../../application/use-cases';
+import { CreatePathDTO, CreatePathSchema, PathQueryDTO, PathQuerySchema } from '../../domain/schemas/learning-path.schema';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+import { LearningPathError } from '../../domain/errors';
+import { ZodError } from 'zod';
+
+export class PathController {
+  constructor(
+    private readonly createPathUseCase: CreatePathUseCase,
+    private readonly getPathUseCase: GetPathUseCase,
+    private readonly listPathsUseCase: ListPathsUseCase
+  ) {}
+
+  createPath = async (
+    request: FastifyRequest<{ Body: CreatePathDTO }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    const startTime = Date.now();
+    const requestId = crypto.randomUUID();
+    const user = request.user as { id: string; email: string; role: string } | undefined;
+
+    try {
+      const validatedData = CreatePathSchema.parse(request.body);
+
+      logger.info({
+        requestId,
+        operation: 'path_creation_request',
+        userId: user?.id,
+        slug: validatedData.slug,
+        title: validatedData.title,
+        category: validatedData.category,
+      }, 'Path creation request received');
+
+      const path = await this.createPathUseCase.execute(validatedData);
+
+      const executionTime = Date.now() - startTime;
+
+      logger.info({
+        requestId,
+        pathId: path.id,
+        slug: path.slug,
+        executionTime,
+      }, 'Path created successfully');
+
+      return reply.status(201).send({
+        success: true,
+        data: path,
+      });
+    } catch (error) {
+      const executionTime = Date.now() - startTime;
+
+      logger.error({
+        requestId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        executionTime,
+      }, 'Failed to create path');
+
+      return this.handleError(error, reply);
+    }
+  };
+
+  getPath = async (
+    request: FastifyRequest<{ Params: { identifier: string }; Querystring: { includeUnits?: string } }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    const { identifier } = request.params;
+    const includeUnits = request.query.includeUnits === 'true';
+
+    try {
+      const path = await this.getPathUseCase.execute(identifier, includeUnits);
+
+      return reply.status(200).send({
+        success: true,
+        data: path,
+      });
+    } catch (error) {
+      logger.error({
+        operation: 'get_path',
+        identifier,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }, 'Failed to get path');
+
+      return this.handleError(error, reply);
+    }
+  };
+
+  listPaths = async (
+    request: FastifyRequest<{ Querystring: PathQueryDTO }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    try {
+      const filters = PathQuerySchema.parse(request.query);
+      const result = await this.listPathsUseCase.execute(filters);
+
+      return reply.status(200).send({
+        success: true,
+        data: result.paths,
+        pagination: {
+          page: result.page,
+          limit: result.limit,
+          total: result.total,
+          totalPages: result.totalPages,
+        },
+      });
+    } catch (error) {
+      logger.error({
+        operation: 'list_paths',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }, 'Failed to list paths');
+
+      return this.handleError(error, reply);
+    }
+  };
+
+  private handleError(error: unknown, reply: FastifyReply): FastifyReply {
+    if (error instanceof ZodError) {
+      return reply.status(400).send({
+        success: false,
+        error: 'Validation error',
+        details: error.errors,
+      });
+    }
+
+    if (error instanceof LearningPathError) {
+      return reply.status(400).send({
+        success: false,
+        error: error.message,
+      });
+    }
+
+    return reply.status(500).send({
+      success: false,
+      error: 'Internal server error',
+    });
+  }
+}

--- a/src/modules/learning-paths/presentation/controllers/unit.controller.ts
+++ b/src/modules/learning-paths/presentation/controllers/unit.controller.ts
@@ -1,0 +1,100 @@
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import { CreateUnitUseCase, GetUnitUseCase, ListUnitsUseCase } from '../../application/use-cases';
+import { CreateUnitDTO, CreateUnitSchema, UnitQueryDTO, UnitQuerySchema } from '../../domain/schemas/learning-path.schema';
+import { logger } from '@/shared/infrastructure/monitoring/logger';
+import { LearningPathError } from '../../domain/errors';
+import { ZodError } from 'zod';
+
+export class UnitController {
+  constructor(
+    private readonly createUnitUseCase: CreateUnitUseCase,
+    private readonly getUnitUseCase: GetUnitUseCase,
+    private readonly listUnitsUseCase: ListUnitsUseCase
+  ) {}
+
+  createUnit = async (
+    request: FastifyRequest<{ Body: CreateUnitDTO }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    try {
+      const validatedData = CreateUnitSchema.parse(request.body);
+      const unit = await this.createUnitUseCase.execute(validatedData);
+
+      return reply.status(201).send({
+        success: true,
+        data: unit,
+      });
+    } catch (error) {
+      logger.error({
+        operation: 'create_unit',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }, 'Failed to create unit');
+
+      return this.handleError(error, reply);
+    }
+  };
+
+  getUnit = async (
+    request: FastifyRequest<{ Params: { identifier: string }; Querystring: { includeLessons?: string } }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    const { identifier } = request.params;
+    const includeLessons = request.query.includeLessons === 'true';
+
+    try {
+      const unit = await this.getUnitUseCase.execute(identifier, includeLessons);
+
+      return reply.status(200).send({
+        success: true,
+        data: unit,
+      });
+    } catch (error) {
+      return this.handleError(error, reply);
+    }
+  };
+
+  listUnits = async (
+    request: FastifyRequest<{ Querystring: UnitQueryDTO }>,
+    reply: FastifyReply
+  ): Promise<void> => {
+    try {
+      const filters = UnitQuerySchema.parse(request.query);
+      const result = await this.listUnitsUseCase.execute(filters);
+
+      return reply.status(200).send({
+        success: true,
+        data: result.units,
+        pagination: {
+          page: result.page,
+          limit: result.limit,
+          total: result.total,
+          totalPages: result.totalPages,
+        },
+      });
+    } catch (error) {
+      return this.handleError(error, reply);
+    }
+  };
+
+  private handleError(error: unknown, reply: FastifyReply): FastifyReply {
+    if (error instanceof ZodError) {
+      return reply.status(400).send({
+        success: false,
+        error: 'Validation error',
+        details: error.errors,
+      });
+    }
+
+    if (error instanceof LearningPathError) {
+      return reply.status(400).send({
+        success: false,
+        error: error.message,
+      });
+    }
+
+    return reply.status(500).send({
+      success: false,
+      error: 'Internal server error',
+    });
+  }
+}

--- a/src/modules/learning-paths/presentation/routes/learning-path.routes.ts
+++ b/src/modules/learning-paths/presentation/routes/learning-path.routes.ts
@@ -1,0 +1,197 @@
+import type { FastifyInstance, RouteHandlerMethod } from 'fastify';
+import { PathController, UnitController, LessonController } from '../controllers';
+
+export async function learningPathRoutes(
+  fastify: FastifyInstance,
+  pathController: PathController,
+  unitController: UnitController,
+  lessonController: LessonController
+): Promise<void> {
+  // Path routes
+  fastify.get('/paths', {
+    preHandler: [fastify.optionalAuth],
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          category: { type: 'string', enum: ['BACKEND', 'FRONTEND', 'FULLSTACK', 'DEVOPS', 'MOBILE', 'DATA'] },
+          isPublished: { type: 'boolean' },
+          targetRole: { type: 'string', enum: ['JUNIOR', 'PLENO', 'SENIOR', 'TECH_LEAD', 'ARCHITECT'] },
+          page: { type: 'number', minimum: 1, default: 1 },
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+        },
+      },
+    },
+    handler: pathController.listPaths as RouteHandlerMethod,
+  });
+
+  fastify.get('/paths/:identifier', {
+    preHandler: [fastify.optionalAuth],
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          identifier: { type: 'string' },
+        },
+        required: ['identifier'],
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          includeUnits: { type: 'string', enum: ['true', 'false'] },
+        },
+      },
+    },
+    handler: pathController.getPath as RouteHandlerMethod,
+  });
+
+  fastify.post('/paths', {
+    preHandler: [fastify.authenticate, fastify.authorize(['SENIOR', 'TECH_LEAD', 'ARCHITECT'])],
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          slug: { type: 'string', minLength: 3, maxLength: 100 },
+          title: { type: 'string', minLength: 3, maxLength: 200 },
+          description: { type: 'string', minLength: 10, maxLength: 2000 },
+          icon: { type: 'string' },
+          color: { type: 'string', pattern: '^#[0-9A-Fa-f]{6}$' },
+          order: { type: 'number', minimum: 0, default: 0 },
+          isPublished: { type: 'boolean', default: false },
+          category: { type: 'string', enum: ['BACKEND', 'FRONTEND', 'FULLSTACK', 'DEVOPS', 'MOBILE', 'DATA'] },
+          targetRole: { type: 'string', enum: ['JUNIOR', 'PLENO', 'SENIOR', 'TECH_LEAD', 'ARCHITECT'] },
+          estimatedHours: { type: 'number', minimum: 0, default: 0 },
+          totalXp: { type: 'number', minimum: 0, default: 0 },
+          metadata: { type: 'object' },
+        },
+        required: ['slug', 'title', 'description', 'category'],
+      },
+    },
+    handler: pathController.createPath as RouteHandlerMethod,
+  });
+
+  // Unit routes
+  fastify.get('/units', {
+    preHandler: [fastify.optionalAuth],
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          pathId: { type: 'string' },
+          isPublished: { type: 'boolean' },
+          page: { type: 'number', minimum: 1, default: 1 },
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+        },
+      },
+    },
+    handler: unitController.listUnits as RouteHandlerMethod,
+  });
+
+  fastify.get('/units/:identifier', {
+    preHandler: [fastify.optionalAuth],
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          identifier: { type: 'string' },
+        },
+        required: ['identifier'],
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          includeLessons: { type: 'string', enum: ['true', 'false'] },
+        },
+      },
+    },
+    handler: unitController.getUnit as RouteHandlerMethod,
+  });
+
+  fastify.post('/units', {
+    preHandler: [fastify.authenticate, fastify.authorize(['SENIOR', 'TECH_LEAD', 'ARCHITECT'])],
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          pathId: { type: 'string' },
+          slug: { type: 'string', minLength: 3, maxLength: 100 },
+          title: { type: 'string', minLength: 3, maxLength: 200 },
+          description: { type: 'string', minLength: 10, maxLength: 2000 },
+          icon: { type: 'string' },
+          order: { type: 'number', minimum: 0, default: 0 },
+          isPublished: { type: 'boolean', default: false },
+          estimatedHours: { type: 'number', minimum: 0, default: 0 },
+          totalXp: { type: 'number', minimum: 0, default: 0 },
+          prerequisites: { type: 'array', items: { type: 'string' } },
+          learningGoals: { type: 'array', items: { type: 'string' } },
+          metadata: { type: 'object' },
+        },
+        required: ['pathId', 'slug', 'title', 'description'],
+      },
+    },
+    handler: unitController.createUnit as RouteHandlerMethod,
+  });
+
+  // Lesson routes
+  fastify.get('/lessons', {
+    preHandler: [fastify.optionalAuth],
+    schema: {
+      querystring: {
+        type: 'object',
+        properties: {
+          unitId: { type: 'string' },
+          lessonType: { type: 'string', enum: ['THEORY', 'PRACTICE', 'QUIZ', 'PROJECT', 'CHALLENGE'] },
+          isPublished: { type: 'boolean' },
+          page: { type: 'number', minimum: 1, default: 1 },
+          limit: { type: 'number', minimum: 1, maximum: 100, default: 20 },
+        },
+      },
+    },
+    handler: lessonController.listLessons as RouteHandlerMethod,
+  });
+
+  fastify.get('/lessons/:identifier', {
+    preHandler: [fastify.optionalAuth],
+    schema: {
+      params: {
+        type: 'object',
+        properties: {
+          identifier: { type: 'string' },
+        },
+        required: ['identifier'],
+      },
+      querystring: {
+        type: 'object',
+        properties: {
+          includeChallenges: { type: 'string', enum: ['true', 'false'] },
+        },
+      },
+    },
+    handler: lessonController.getLesson as RouteHandlerMethod,
+  });
+
+  fastify.post('/lessons', {
+    preHandler: [fastify.authenticate, fastify.authorize(['SENIOR', 'TECH_LEAD', 'ARCHITECT'])],
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          unitId: { type: 'string' },
+          slug: { type: 'string', minLength: 3, maxLength: 100 },
+          title: { type: 'string', minLength: 3, maxLength: 200 },
+          description: { type: 'string', minLength: 10, maxLength: 2000 },
+          icon: { type: 'string' },
+          order: { type: 'number', minimum: 0, default: 0 },
+          isPublished: { type: 'boolean', default: false },
+          lessonType: { type: 'string', enum: ['THEORY', 'PRACTICE', 'QUIZ', 'PROJECT', 'CHALLENGE'], default: 'PRACTICE' },
+          estimatedMinutes: { type: 'number', minimum: 1, maximum: 240, default: 15 },
+          xpReward: { type: 'number', minimum: 0, default: 50 },
+          content: { type: 'object' },
+          metadata: { type: 'object' },
+        },
+        required: ['unitId', 'slug', 'title', 'description'],
+      },
+    },
+    handler: lessonController.createLesson as RouteHandlerMethod,
+  });
+}


### PR DESCRIPTION
…red by Duolingo

Database Schema (Prisma):
* Add Path model with slug, title, description, category, and targetRole
* Add Unit model with pathId relationship and prerequisites system
* Add Lesson model with unitId relationship and lessonType enum
* Create LessonType enum (THEORY, PRACTICE, QUIZ, PROJECT, CHALLENGE)
* Update Challenge model to optionally link to Lesson via lessonId
* Add proper indexes for performance (slug, category, order, isPublished)
* Implement cascade deletes for hierarchical relationships
* Create migration SQL with all tables, indexes, and foreign keys

Domain Layer (Clean Architecture):
* Create PathEntity with business logic for role-based access control
* Create UnitEntity with prerequisite validation and progress calculation
* Create LessonEntity with type-specific behavior and time estimation
* Define repository interfaces for Path, Unit, and Lesson
* Implement comprehensive Zod schemas for all DTOs with validation rules
* Create TypeScript types for entities with relations and metadata
* Build error hierarchy with 7 specific errors (NotFound, SlugExists per entity)

Application Layer (Use Cases):
* Implement CreatePathUseCase with slug uniqueness validation
* Implement CreateUnitUseCase with path existence verification
* Implement CreateLessonUseCase with unit existence verification
* Add GetPath/Unit/LessonUseCase supporting ID or slug lookup
* Add ListPaths/Units/LessonsUseCase with pagination and filtering
* Support optional relation loading (includeUnits, includeLessons, includeChallenges)
* Add comprehensive logging for all operations with timing metrics

Infrastructure Layer (Repositories):
* Implement PathRepository with Prisma including count and exists methods
* Implement UnitRepository with reorder capability for drag-drop support
* Implement LessonRepository with reorder capability for sequencing
* Add filtering by category, role, type, published status, and parent IDs
* Support pagination with page, limit, skip, and total count
* Implement proper error handling and logging for all database operations
* Use Prisma includes for efficient relation loading

Presentation Layer (Controllers & Routes):
* Create PathController with create, get, and list endpoints
* Create UnitController with create, get, and list endpoints
* Create LessonController with create, get, and list endpoints
* Define Fastify routes with comprehensive schema validation
* Implement GET /learning-paths/paths with optional includeUnits
* Implement GET /learning-paths/units with optional includeLessons
* Implement GET /learning-paths/lessons with optional includeChallenges
* Add POST endpoints requiring SENIOR+ role authorization
* Support query params for filtering and pagination on all list endpoints

Plugin Integration:
* Create LearningPathPlugin following Fastify plugin pattern
* Initialize all repositories with Prisma client injection
* Wire up use cases with repository dependencies
* Instantiate controllers with use case dependencies
* Register routes under /learning-paths prefix
* Set auth-plugin as dependency for authentication support

Hierarchical Structure:
* Path → Unit → Lesson → Challenge relationship chain
* Path contains multiple Units with ordering
* Unit contains multiple Lessons with prerequisites
* Lesson contains multiple Challenges (existing model)
* Support for published/unpublished content at each level
* Metadata JSON fields for extensibility at all levels

This commit establishes the foundation for a Duolingo-inspired learning experience with organized paths, units, and lessons that progressively guide users through challenges. The implementation follows DDD architecture with clear separation of concerns across domain, application, infrastructure, and presentation layers.